### PR TITLE
#1700 [Control] fix: no display success_score if no percentage questions

### DIFF
--- a/view/control/control_card.php
+++ b/view/control/control_card.php
@@ -720,28 +720,14 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 	print saturne_show_medias_linked('digiquali', $pathPhotos, 'small', 0, 0, 0, 0, $onPhone ? 40 : 50, $onPhone ? 40 : 50, 0, 0, 0, 'control/'. $object->ref . '/photos/', $object, 'photo', $object->status < Control::STATUS_LOCKED, $permissiontodelete && $object->status < Control::STATUS_LOCKED);
 	print '</td></tr>';
 
-    print '<tr class="field_success_rate"><td class="titlefield fieldname_success_rate">';
-    print $form->editfieldkey('SuccessScore', 'success_rate', $object->success_rate, $object, $permissiontoadd && $object->status < Control::STATUS_LOCKED, 'string', '', 0, 0,'id', $langs->trans('PercentageValue'));
-    print '</td><td class="valuefield fieldname_success_rate">';
-    if ($action == 'editsuccess_rate') {
-        print '<form action="' . $_SERVER['PHP_SELF'] . '?id=' . $object->id . '" method="post">';
-        print '<input type="hidden" name="token" value="' . newToken() . '">';
-        print '<input type="hidden" name="action" value="setsuccess_rate">';
-        print '<table class="nobordernopadding centpercent">';
-        print '<tbody><tr><td><input type="number" id="success_rate" name="success_rate" min="0" max="100" onkeyup=window.saturne.utils.enforceMinMax(this) value="' . $object->success_rate . '">';
-        print '</td><td class="left"><input type="submit" class="smallpaddingimp button" name="modify" value="' . $langs->trans('Modify') . '"><input type="submit" class="smallpaddingimp button button-cancel" name="cancel" value="' . $langs->trans('Cancel') . '"></td></tr></tbody></table>';
-        print '</form>';
-    } else {
-        print price2num($object->success_rate) . ' %';
-    }
-    print '</td></tr>';
-
     $averagePercentageQuestions = 0;
+    $percentQuestionCounter     = 0;
     foreach ($sheet->linkedObjects['digiquali_question'] as $questionLinked) {
         if ($questionLinked->type !== 'Percentage') {
             continue; // Skip non-percentage questions
         }
 
+        $percentQuestionCounter++;
         foreach ($object->lines as $line) {
             if ($line->fk_question === $questionLinked->id) {
                 $averagePercentageQuestions += $line->answer;
@@ -749,9 +735,25 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
         }
     }
 
-    $averagePercentageQuestions = ($questionCounter > 0) ? ($averagePercentageQuestions / $questionCounter) : 0;
+    $averagePercentageQuestions = ($percentQuestionCounter > 0) ? ($averagePercentageQuestions / $percentQuestionCounter) : 0;
 
-    if ($averagePercentageQuestions > 0) {
+    if ($percentQuestionCounter > 0) {
+        print '<tr class="field_success_rate"><td class="titlefield fieldname_success_rate">';
+        print $form->editfieldkey('SuccessScore', 'success_rate', $object->success_rate, $object, $permissiontoadd && $object->status < Control::STATUS_LOCKED, 'string', '', 0, 0,'id', $langs->trans('PercentageValue'));
+        print '</td><td class="valuefield fieldname_success_rate">';
+        if ($action == 'editsuccess_rate') {
+            print '<form action="' . $_SERVER['PHP_SELF'] . '?id=' . $object->id . '" method="post">';
+            print '<input type="hidden" name="token" value="' . newToken() . '">';
+            print '<input type="hidden" name="action" value="setsuccess_rate">';
+            print '<table class="nobordernopadding centpercent">';
+            print '<tbody><tr><td><input type="number" id="success_rate" name="success_rate" min="0" max="100" onkeyup=window.saturne.utils.enforceMinMax(this) value="' . $object->success_rate . '">';
+            print '</td><td class="left"><input type="submit" class="smallpaddingimp button" name="modify" value="' . $langs->trans('Modify') . '"><input type="submit" class="smallpaddingimp button button-cancel" name="cancel" value="' . $langs->trans('Cancel') . '"></td></tr></tbody></table>';
+            print '</form>';
+        } else {
+            print price2num($object->success_rate) . ' %';
+        }
+        print '</td></tr>';
+
         print '<tr class="field_average"><td class="titlefield fieldname_average">';
         print $langs->trans('AveragePercentageQuestions');
         print '</td><td class="valuefield fieldname_average">';


### PR DESCRIPTION
And divide averagePercentageQuestions by percentQuestionCounter and not by questionCounter