### PR TITLE
Fix Postgresql compatibility

### DIFF
--- a/class/actions_digiquali.class.php
+++ b/class/actions_digiquali.class.php
@@ -211,7 +211,7 @@ class ActionsDigiquali
             if (isModEnabled('easyurl')) {
                 require_once DOL_DOCUMENT_ROOT . '/custom/easyurl/class/shortener.class.php';
                 $shortener = new Shortener($this->db);
-                $result    = $shortener->fetch('', '', ' AND t.original_url = "' . $publicControlInterfaceUrl . '"');
+                $result    = $shortener->fetch('', '', ' AND t.original_url = \'' . $publicControlInterfaceUrl . '\'');
                 if ($result > 0) {
                     $publicControlInterfaceUrl = $shortener->short_url;
                 } else {
@@ -289,7 +289,7 @@ class ActionsDigiquali
             if (isModEnabled('easyurl')) {
                 require_once DOL_DOCUMENT_ROOT . '/custom/easyurl/class/shortener.class.php';
                 $shortener = new Shortener($this->db);
-                $result    = $shortener->fetch('', '', ' AND t.original_url = "' . $publicControlInterfaceUrl . '"');
+                $result    = $shortener->fetch('', '', ' AND t.original_url = \'' . $publicControlInterfaceUrl . '\'');
                 if ($result > 0) {
                     $publicControlInterfaceUrl = $shortener->short_url;
                 } else {

--- a/class/sheet.class.php
+++ b/class/sheet.class.php
@@ -486,9 +486,9 @@ class Sheet extends SaturneObject
             $sql  = 'UPDATE '. MAIN_DB_PREFIX . 'element_element';
             $sql .= ' SET position = ' . $position;
             $sql .= ' WHERE fk_source = ' . $this->id;
-            $sql .= ' AND sourcetype = "digiquali_sheet"';
+            $sql .= ' AND sourcetype = \'digiquali_sheet\'';
             $sql .= ' AND fk_target = ' . $questionIds[$position];
-            $sql .= ' AND targettype = "digiquali_question"';
+            $sql .= ' AND targettype = \'digiquali_question\'';
             $res  = $this->db->query($sql);
 
             if (!$res) {

--- a/core/modules/modDigiQuali.class.php
+++ b/core/modules/modDigiQuali.class.php
@@ -792,7 +792,7 @@ class modDigiQuali extends DolibarrModules
 			$question  = new Question($this->db);
 			$answer    = new Answer($this->db);
 
-			$questions = $question->fetchAll('', '', 0, 0, ['customsql' => 't.type = "OkKoToFixNonApplicable"']);
+			$questions = $question->fetchAll('', '', 0, 0, ['customsql' => 't.type = \'OkKoToFixNonApplicable\'']);
 			if (is_array($questions) && !empty($questions)) {
 				foreach ($questions as $question) {
 					$answer->fk_question = $question->id;

--- a/core/tpl/digiquali_control_list.tpl.php
+++ b/core/tpl/digiquali_control_list.tpl.php
@@ -414,7 +414,7 @@ while ($i < ($limit ? min($num, $limit) : $num))
 	// Store properties in $object
 	$object->setVarsFromFetchObj($obj);
 
-    $filter      = ['customsql' => 'fk_object=' . $object->id . ' AND status > 0 AND object_type="' . $object->element . '"'];
+    $filter      = ['customsql' => 'fk_object=' . $object->id . ' AND status > 0 AND object_type=\'' . $object->element . '\''];
     $signatories = $signatory->fetchAll('', 'role', 0, 0, $filter);
 
 	// Show here line of result

--- a/core/tpl/digiquali_control_list.tpl.php
+++ b/core/tpl/digiquali_control_list.tpl.php
@@ -37,12 +37,12 @@ $sql = preg_replace('/,\s*$/', '', $sql);
 foreach($elementElementFields as $genericName => $elementElementName) {
     if (GETPOST('search_' . $genericName) > 0 || $fromtype == $elementElementName) {
         $id_tosearch = GETPOST('search' . $genericName) ?: $fromid;
-        $sql .= ', ' .  $elementElementName . '.fk_source, ';
+        $sql .= ', "' .  $elementElementName . '".fk_source, ';
     }
 }
 $sql = rtrim($sql, ', ');
 if (array_key_exists($sortfield, $elementElementFields) && !preg_match('/' . 'LEFT JOIN ' . MAIN_DB_PREFIX . 'element_element as ' . $elementElementFields[$sortfield] . '/', $sql)) {
-    $sql .= ',' .  $elementElementFields[$sortfield] . '.fk_source';
+    $sql .= ', "' .  $elementElementFields[$sortfield] . '".fk_source';
 }
 $sql .= " FROM ".MAIN_DB_PREFIX.$object->table_element." as t";
 if (!empty($conf->categorie->enabled)) {
@@ -53,12 +53,12 @@ if (is_array($extrafields->attributes[$object->table_element]['label']) && count
 foreach($elementElementFields as $genericName => $elementElementName) {
 	if (GETPOST('search_'.$genericName) > 0 || $fromtype == $elementElementName) {
 		$id_to_search = GETPOST('search_'.$genericName) ?: $fromid;
-		$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'element_element as '. $elementElementName .' on ('. $elementElementName .'.fk_source = ' . $id_to_search . ' AND '. $elementElementName .'.sourcetype=\''. $elementElementName .'\' AND '. $elementElementName .'.targettype = \'digiquali_control\')';
+		$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'element_element as "'. $elementElementName .'" on ("'. $elementElementName .'".fk_source = ' . $id_to_search . ' AND "'. $elementElementName .'".sourcetype=\''. $elementElementName .'\' AND "'. $elementElementName .'".targettype = \'digiquali_control\')';
 	}
 }
 
 if (array_key_exists($sortfield,$elementElementFields) && !preg_match('/' . 'LEFT JOIN ' . MAIN_DB_PREFIX . 'element_element as '. $elementElementFields[$sortfield] .'/', $sql)) {
-	$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'element_element as '. $elementElementFields[$sortfield] .' on ( '. $elementElementFields[$sortfield] .'.sourcetype=\''. $elementElementFields[$sortfield] .'\' AND '. $elementElementFields[$sortfield] .'.targettype = \'digiquali_control\' AND '. $elementElementFields[$sortfield] .'.fk_target = t.rowid)';
+	$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'element_element as '. $elementElementFields[$sortfield] .' on ( "'. $elementElementFields[$sortfield] .'".sourcetype=\''. $elementElementFields[$sortfield] .'\' AND "'. $elementElementFields[$sortfield] .'".targettype = \'digiquali_control\' AND "'. $elementElementFields[$sortfield] .'".fk_target = t.rowid)';
 }
 
 // Add table from hooks
@@ -71,7 +71,7 @@ $sql .= ' AND status > -1';
 
 foreach($elementElementFields as $genericName => $elementElementName) {
 	if (GETPOST('search_'.$genericName) > 0 || $fromtype == $elementElementName) {
-		$sql .= ' AND t.rowid = '. $elementElementName .'.fk_target ';
+		$sql .= ' AND t.rowid = "'. $elementElementName .'".fk_target ';
 	}
 }
 

--- a/core/tpl/digiquali_control_list.tpl.php
+++ b/core/tpl/digiquali_control_list.tpl.php
@@ -540,8 +540,8 @@ while ($i < ($limit ? min($num, $limit) : $num))
 
                         $actioncomm = new ActionComm($db);
 
-                        $lastValidateAction = $actioncomm->getActions(0, $object->id, 'control@digiquali', ' AND a.code = "AC_CONTROL_VALIDATE"', 'a.datep', 'DESC', 1);
-                        $lastReOpenAction   = $actioncomm->getActions(0, $object->id, 'control@digiquali', ' AND a.code = "AC_CONTROL_UNVALIDATE"', 'a.datep', 'DESC', 1);
+                        $lastValidateAction = $actioncomm->getActions(0, $object->id, 'control@digiquali', ' AND a.code = \'AC_CONTROL_VALIDATE\'', 'a.datep', 'DESC', 1);
+                        $lastReOpenAction   = $actioncomm->getActions(0, $object->id, 'control@digiquali', ' AND a.code = \'AC_CONTROL_UNVALIDATE\'', 'a.datep', 'DESC', 1);
 
                         $lastValidateDate   = (is_array($lastValidateAction) && !empty($lastValidateAction) ? $lastValidateAction[0]->datec : 0);
                         $lastReOpenDate     = (is_array($lastReOpenAction) && !empty($lastReOpenAction) ? $lastReOpenAction[0]->datec : '');

--- a/core/tpl/digiquali_control_list.tpl.php
+++ b/core/tpl/digiquali_control_list.tpl.php
@@ -37,7 +37,7 @@ $sql = preg_replace('/,\s*$/', '', $sql);
 foreach($elementElementFields as $genericName => $elementElementName) {
     if (GETPOST('search_' . $genericName) > 0 || $fromtype == $elementElementName) {
         $id_tosearch = GETPOST('search' . $genericName) ?: $fromid;
-        $sql .= ',' .  $elementElementName . '.fk_source, ';
+        $sql .= ', ' .  $elementElementName . '.fk_source, ';
     }
 }
 $sql = rtrim($sql, ', ');

--- a/core/tpl/digiquali_control_list.tpl.php
+++ b/core/tpl/digiquali_control_list.tpl.php
@@ -53,12 +53,12 @@ if (is_array($extrafields->attributes[$object->table_element]['label']) && count
 foreach($elementElementFields as $genericName => $elementElementName) {
 	if (GETPOST('search_'.$genericName) > 0 || $fromtype == $elementElementName) {
 		$id_to_search = GETPOST('search_'.$genericName) ?: $fromid;
-		$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'element_element as '. $elementElementName .' on ('. $elementElementName .'.fk_source = ' . $id_to_search . ' AND '. $elementElementName .'.sourcetype="'. $elementElementName .'" AND '. $elementElementName .'.targettype = "digiquali_control")';
+		$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'element_element as '. $elementElementName .' on ('. $elementElementName .'.fk_source = ' . $id_to_search . ' AND '. $elementElementName .'.sourcetype=\''. $elementElementName .'\' AND '. $elementElementName .'.targettype = \'digiquali_control\')';
 	}
 }
 
 if (array_key_exists($sortfield,$elementElementFields) && !preg_match('/' . 'LEFT JOIN ' . MAIN_DB_PREFIX . 'element_element as '. $elementElementFields[$sortfield] .'/', $sql)) {
-	$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'element_element as '. $elementElementFields[$sortfield] .' on ( '. $elementElementFields[$sortfield] .'.sourcetype="'. $elementElementFields[$sortfield] .'" AND '. $elementElementFields[$sortfield] .'.targettype = "digiquali_control" AND '. $elementElementFields[$sortfield] .'.fk_target = t.rowid)';
+	$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'element_element as '. $elementElementFields[$sortfield] .' on ( '. $elementElementFields[$sortfield] .'.sourcetype=\''. $elementElementFields[$sortfield] .'\' AND '. $elementElementFields[$sortfield] .'.targettype = \'digiquali_control\' AND '. $elementElementFields[$sortfield] .'.fk_target = t.rowid)';
 }
 
 // Add table from hooks
@@ -320,7 +320,7 @@ foreach ($object->fields as $key => $val)
 			print $form->selectarray('search_' . $key, $val['arrayofkeyval'], $search[$key], $val['notnull'], 0, 0, '', 1, 0, 0, '', 'minwidth200', 1);
 		}
 		elseif ($key == 'fk_sheet') {
-			print $sheet->selectSheetList(GETPOST('fromtype') == 'fk_sheet' ? GETPOST('fromid') : ($search['fk_sheet'] ?: 0), 'search_fk_sheet', 's.type = ' . '"' . $object->element . '"');
+			print $sheet->selectSheetList(GETPOST('fromtype') == 'fk_sheet' ? GETPOST('fromid') : ($search['fk_sheet'] ?: 0), 'search_fk_sheet', 's.type = ' . "'" . $object->element . "'");
 		}
 		elseif (strpos($val['type'], 'integer:') === 0) {
 			print $object->showInputField($val, $key, $search[$key], '', '', 'search_', 'minwidth100 maxwidth125 widthcentpercentminusxx', 1);

--- a/core/tpl/digiquali_survey_list.tpl.php
+++ b/core/tpl/digiquali_survey_list.tpl.php
@@ -37,12 +37,12 @@ if (is_array($extrafields->attributes[$object->table_element]['label']) && count
 foreach($elementElementFields as $genericName => $elementElementName) {
 	if (GETPOST('search_'.$genericName) > 0 || $fromtype == $elementElementName) {
 		$id_to_search = GETPOST('search_'.$genericName) ?: $fromid;
-		$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'element_element as '. $elementElementName .' on ('. $elementElementName .'.fk_source = ' . $id_to_search . ' AND '. $elementElementName .'.sourcetype="'. $elementElementName .'" AND '. $elementElementName .'.targettype = "digiquali_survey")';
+		$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'element_element as '. $elementElementName .' on ('. $elementElementName .'.fk_source = ' . $id_to_search . ' AND '. $elementElementName .'.sourcetype=\''. $elementElementName .'\' AND '. $elementElementName .'.targettype = "digiquali_survey")';
 	}
 }
 
 if (array_key_exists($sortfield,$elementElementFields) && !preg_match('/' . 'LEFT JOIN ' . MAIN_DB_PREFIX . 'element_element as '. $elementElementFields[$sortfield] .'/', $sql)) {
-	$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'element_element as '. $elementElementFields[$sortfield] .' on ( '. $elementElementFields[$sortfield] .'.sourcetype="'. $elementElementFields[$sortfield] .'" AND '. $elementElementFields[$sortfield] .'.targettype = "digiquali_survey" AND '. $elementElementFields[$sortfield] .'.fk_target = t.rowid)';
+	$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'element_element as '. $elementElementFields[$sortfield] .' on ( '. $elementElementFields[$sortfield] .'.sourcetype=\''. $elementElementFields[$sortfield] .'\' AND '. $elementElementFields[$sortfield] .'.targettype = "digiquali_survey" AND '. $elementElementFields[$sortfield] .'.fk_target = t.rowid)';
 }
 
 // Add table from hooks
@@ -449,7 +449,7 @@ while ($i < $imaxinloop) {
     // Store properties in $object
     $object->setVarsFromFetchObj($obj);
 
-    $filter      = ['customsql' => 'fk_object = ' . $object->id . ' AND status > 0 AND object_type = "' . $object->element . '"'];
+    $filter      = ['customsql' => 'fk_object = ' . $object->id . ' AND status > 0 AND object_type = \'' . $object->element . '\''];
     $signatories = $signatory->fetchAll('', 'role', 0, 0, $filter);
 
     if ($mode == 'kanban') {
@@ -594,8 +594,8 @@ while ($i < $imaxinloop) {
 
                             $actioncomm = new ActionComm($db);
 
-                            $lastValidateAction = $actioncomm->getActions(0, $object->id, 'survey@digiquali', ' AND a.code = "AC_SURVEY_VALIDATE"', 'a.datep', 'DESC', 1);
-                            $lastReOpenAction   = $actioncomm->getActions(0, $object->id, 'survey@digiquali', ' AND a.code = "AC_SURVEY_UNVALIDATE"', 'a.datep', 'DESC', 1);
+                            $lastValidateAction = $actioncomm->getActions(0, $object->id, 'survey@digiquali', ' AND a.code = \'AC_SURVEY_VALIDATE\'', 'a.datep', 'DESC', 1);
+                            $lastReOpenAction   = $actioncomm->getActions(0, $object->id, 'survey@digiquali', ' AND a.code = \'AC_SURVEY_UNVALIDATE\'', 'a.datep', 'DESC', 1);
 
                             $lastValidateDate = (is_array($lastValidateAction) && !empty($lastValidateAction) ? $lastValidateAction[0]->datec : 0);
                             $lastReOpenDate   = (is_array($lastReOpenAction) && !empty($lastReOpenAction) ? $lastReOpenAction[0]->datec : 0);

--- a/core/tpl/digiquali_survey_list.tpl.php
+++ b/core/tpl/digiquali_survey_list.tpl.php
@@ -334,7 +334,7 @@ foreach ($object->fields as $key => $val)
 			print $form->selectarray('search_' . $key, $val['arrayofkeyval'], $search[$key], $val['notnull'], 0, 0, '', 1, 0, 0, '', 'minwidth200', 1);
 		}
 		elseif ($key == 'fk_sheet') {
-			print $sheet->selectSheetList(GETPOST('fromtype') == 'fk_sheet' ? GETPOST('fromid') : ($search['fk_sheet'] ?: 0), 'search_fk_sheet', 's.type = ' . '"' . $object->element . '"');
+			print $sheet->selectSheetList(GETPOST('fromtype') == 'fk_sheet' ? GETPOST('fromid') : ($search['fk_sheet'] ?: 0), 'search_fk_sheet', 's.type = \'' . $object->element . '\'');
 		}
 		elseif (strpos($val['type'], 'integer:') === 0) {
 			print $object->showInputField($val, $key, $search[$key], '', '', 'search_', 'minwidth100 maxwidth125 widthcentpercentminusxx', 1);

--- a/core/tpl/digiquali_survey_list.tpl.php
+++ b/core/tpl/digiquali_survey_list.tpl.php
@@ -21,12 +21,12 @@ $sql = preg_replace('/,\s*$/', '', $sql);
 foreach($elementElementFields as $genericName => $elementElementName) {
     if (GETPOST('search_' . $genericName) > 0 || $fromtype == $elementElementName) {
         $id_tosearch = GETPOST('search' . $genericName) ?: $fromid;
-        $sql .= ',' .  $elementElementName . '.fk_source, ';
+        $sql .= ', "' .  $elementElementName . '".fk_source, ';
     }
 }
 $sql = rtrim($sql, ', ');
 if (array_key_exists($sortfield, $elementElementFields) && !preg_match('/' . 'LEFT JOIN ' . MAIN_DB_PREFIX . 'element_element as ' . $elementElementFields[$sortfield] . '/', $sql)) {
-    $sql .= ',' .  $elementElementFields[$sortfield] . '.fk_source';
+    $sql .= ', "' .  $elementElementFields[$sortfield] . '".fk_source';
 }
 $sql .= ' FROM ' . MAIN_DB_PREFIX . $object->table_element . ' as t';
 if (!empty($conf->categorie->enabled)) {
@@ -37,12 +37,12 @@ if (is_array($extrafields->attributes[$object->table_element]['label']) && count
 foreach($elementElementFields as $genericName => $elementElementName) {
 	if (GETPOST('search_'.$genericName) > 0 || $fromtype == $elementElementName) {
 		$id_to_search = GETPOST('search_'.$genericName) ?: $fromid;
-		$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'element_element as '. $elementElementName .' on ('. $elementElementName .'.fk_source = ' . $id_to_search . ' AND '. $elementElementName .'.sourcetype=\''. $elementElementName .'\' AND '. $elementElementName .'.targettype = "digiquali_survey")';
+		$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'element_element as "'. $elementElementName .'" on ("'. $elementElementName .'".fk_source = ' . $id_to_search . ' AND "'. $elementElementName .'".sourcetype=\''. $elementElementName .'\' AND "'. $elementElementName .'".targettype = \'digiquali_survey\')';
 	}
 }
 
 if (array_key_exists($sortfield,$elementElementFields) && !preg_match('/' . 'LEFT JOIN ' . MAIN_DB_PREFIX . 'element_element as '. $elementElementFields[$sortfield] .'/', $sql)) {
-	$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'element_element as '. $elementElementFields[$sortfield] .' on ( '. $elementElementFields[$sortfield] .'.sourcetype=\''. $elementElementFields[$sortfield] .'\' AND '. $elementElementFields[$sortfield] .'.targettype = "digiquali_survey" AND '. $elementElementFields[$sortfield] .'.fk_target = t.rowid)';
+	$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'element_element as "'. $elementElementFields[$sortfield] .'" on ( "'. $elementElementFields[$sortfield] .'".sourcetype=\''. $elementElementFields[$sortfield] .'\' AND "'. $elementElementFields[$sortfield] .'".targettype = \'digiquali_survey\' AND "'. $elementElementFields[$sortfield] .'".fk_target = t.rowid)';
 }
 
 // Add table from hooks
@@ -58,7 +58,7 @@ $sql .= ' AND t.status >= ' . Survey::STATUS_DRAFT;
 
 foreach($elementElementFields as $genericName => $elementElementName) {
     if (GETPOST('search_'.$genericName) > 0 || $fromtype == $elementElementName) {
-        $sql .= ' AND t.rowid = ' . $elementElementName . '.fk_target ';
+        $sql .= ' AND t.rowid = "' . $elementElementName . '".fk_target ';
     }
 }
 
@@ -130,7 +130,7 @@ if (empty($conf->global->MAIN_DISABLE_FULL_SCANLIST)) {
 
 // Complete request and execute it with limit
 if (array_key_exists($sortfield, $elementElementFields)) {
-    $sql .= ' ORDER BY '. $elementElementFields[$sortfield] . '.fk_source ' . $sortorder;
+    $sql .= ' ORDER BY "'. $elementElementFields[$sortfield] . '".fk_source ' . $sortorder;
 } else {
     $sql .= $db->order($sortfield, $sortorder);
 }

--- a/sql/data.sql
+++ b/sql/data.sql
@@ -15,16 +15,16 @@
 
 -- 1.6.0
 
-INSERT INTO `llx_c_question_type` (`rowid`, `entity`, `ref`, `label`, `description`, `active`, `position`) VALUES(1, 0, 'UniqueChoice', 'UniqueChoice', '', 1, 1);
-INSERT INTO `llx_c_question_type` (`rowid`, `entity`, `ref`, `label`, `description`, `active`, `position`) VALUES(2, 0, 'MultipleChoices', 'MultipleChoices', '', 1, 10);
-INSERT INTO `llx_c_question_type` (`rowid`, `entity`, `ref`, `label`, `description`, `active`, `position`) VALUES(3, 0, 'Text', 'Text', '', 1, 20);
-INSERT INTO `llx_c_question_type` (`rowid`, `entity`, `ref`, `label`, `description`, `active`, `position`) VALUES(4, 0, 'Percentage', 'Percentage', '', 1, 30);
-INSERT INTO `llx_c_question_type` (`rowid`, `entity`, `ref`, `label`, `description`, `active`, `position`) VALUES(5, 0, 'Range', 'Range', '', 1, 40);
-INSERT INTO `llx_c_question_type` (`rowid`, `entity`, `ref`, `label`, `description`, `active`, `position`) VALUES(6, 0, 'OkKo', 'OkKo', '', 1, 50);
-INSERT INTO `llx_c_question_type` (`rowid`, `entity`, `ref`, `label`, `description`, `active`, `position`) VALUES(7, 0, 'OkKoToFixNonApplicable', 'OkKoToFixNonApplicable', '', 1, 60);
+INSERT INTO llx_c_question_type (rowid, entity, ref, label, description, active, position) VALUES(1, 0, 'UniqueChoice', 'UniqueChoice', '', 1, 1);
+INSERT INTO llx_c_question_type (rowid, entity, ref, label, description, active, position) VALUES(2, 0, 'MultipleChoices', 'MultipleChoices', '', 1, 10);
+INSERT INTO llx_c_question_type (rowid, entity, ref, label, description, active, position) VALUES(3, 0, 'Text', 'Text', '', 1, 20);
+INSERT INTO llx_c_question_type (rowid, entity, ref, label, description, active, position) VALUES(4, 0, 'Percentage', 'Percentage', '', 1, 30);
+INSERT INTO llx_c_question_type (rowid, entity, ref, label, description, active, position) VALUES(5, 0, 'Range', 'Range', '', 1, 40);
+INSERT INTO llx_c_question_type (rowid, entity, ref, label, description, active, position) VALUES(6, 0, 'OkKo', 'OkKo', '', 1, 50);
+INSERT INTO llx_c_question_type (rowid, entity, ref, label, description, active, position) VALUES(7, 0, 'OkKoToFixNonApplicable', 'OkKoToFixNonApplicable', '', 1, 60);
 
-INSERT INTO `llx_c_control_attendants_role` (`rowid`, `entity`, `ref`, `label`, `description`, `active`, `position`) VALUES(1, 0, 'Controller', 'Controller', '', 1, 1);
-INSERT INTO `llx_c_control_attendants_role` (`rowid`, `entity`, `ref`, `label`, `description`, `active`, `position`) VALUES(2, 0, 'Attendant', 'Attendant', '', 1, 20);
+INSERT INTO llx_c_control_attendants_role (rowid, entity, ref, label, description, active, position) VALUES(1, 0, 'Controller', 'Controller', '', 1, 1);
+INSERT INTO llx_c_control_attendants_role (rowid, entity, ref, label, description, active, position) VALUES(2, 0, 'Attendant', 'Attendant', '', 1, 20);
 
 -- 1.11.0
-INSERT INTO `llx_c_survey_attendants_role` (`rowid`, `entity`, `ref`, `label`, `description`, `active`, `position`) VALUES(1, 0, 'Attendant', 'Attendant', '', 1, 1);
+INSERT INTO llx_c_survey_attendants_role (rowid, entity, ref, label, description, active, position) VALUES(1, 0, 'Attendant', 'Attendant', '', 1, 1);

--- a/sql/update.sql
+++ b/sql/update.sql
@@ -14,119 +14,119 @@
 -- along with this program.  If not, see https://www.gnu.org/licenses/.
 
 -- 1.1.0
-ALTER TABLE `llx_dolismq_controldet` ADD `answer_photo` TEXT NOT NULL AFTER `answer`;
+ALTER TABLE llx_dolismq_controldet ADD answer_photo TEXT NOT NULL AFTER answer;
 
 -- 1.2.0
-ALTER TABLE `llx_dolismq_control` ADD `note_public` TEXT NULL AFTER `status`;
-ALTER TABLE `llx_dolismq_control` ADD `note_private` TEXT NULL AFTER `note_public`;
-ALTER TABLE `llx_dolismq_control` DROP `fk_product`;
-ALTER TABLE `llx_dolismq_control` DROP `fk_lot`;
-ALTER TABLE `llx_dolismq_control` DROP `fk_soc`;
-ALTER TABLE `llx_dolismq_control` DROP `fk_project`;
-ALTER TABLE `llx_dolismq_control` DROP `fk_task`;
+ALTER TABLE llx_dolismq_control ADD note_public TEXT NULL AFTER status;
+ALTER TABLE llx_dolismq_control ADD note_private TEXT NULL AFTER note_public;
+ALTER TABLE llx_dolismq_control DROP fk_product;
+ALTER TABLE llx_dolismq_control DROP fk_lot;
+ALTER TABLE llx_dolismq_control DROP fk_soc;
+ALTER TABLE llx_dolismq_control DROP fk_project;
+ALTER TABLE llx_dolismq_control DROP fk_task;
 
 -- 1.3.0
-ALTER TABLE `llx_dolismq_sheet` ADD `element_linked` TEXT NULL AFTER `label`;
+ALTER TABLE llx_dolismq_sheet ADD element_linked TEXT NULL AFTER label;
 
-ALTER TABLE `llx_dolismq_question` ADD `show_photo` BOOLEAN NULL AFTER `description`;
-ALTER TABLE `llx_dolismq_question` ADD `authorize_answer_photo` BOOLEAN NULL AFTER `show_photo`;
-ALTER TABLE `llx_dolismq_question` ADD `enter_comment` BOOLEAN NULL AFTER `authorize_answer_photo`;
+ALTER TABLE llx_dolismq_question ADD show_photo BOOLEAN NULL AFTER description;
+ALTER TABLE llx_dolismq_question ADD authorize_answer_photo BOOLEAN NULL AFTER show_photo;
+ALTER TABLE llx_dolismq_question ADD enter_comment BOOLEAN NULL AFTER authorize_answer_photo;
 
-ALTER TABLE `llx_dolismq_control` ADD `fk_project` INTEGER NULL AFTER `fk_user_controller`;
+ALTER TABLE llx_dolismq_control ADD fk_project INTEGER NULL AFTER fk_user_controller;
 
 -- 1.4.0
-ALTER TABLE `llx_dolismq_control` CHANGE `fk_project` `projectid` integer;
-ALTER TABLE `llx_element_element` ADD `position` INTEGER;
-UPDATE `llx_element_element` SET `sourcetype` = 'dolismq_question' WHERE `sourcetype` = 'question';
-UPDATE `llx_element_element` SET `sourcetype` = 'dolismq_sheet' WHERE `sourcetype` = 'sheet';
-UPDATE `llx_element_element` SET `sourcetype` = 'dolismq_control' WHERE `sourcetype` = 'control';
-UPDATE `llx_element_element` SET `targettype` = 'dolismq_question' WHERE `targettype` = 'question';
-UPDATE `llx_element_element` SET `targettype` = 'dolismq_sheet' WHERE `targettype` = 'sheet';
-UPDATE `llx_element_element` SET `targettype` = 'dolismq_control' WHERE `targettype` = 'control';
+ALTER TABLE llx_dolismq_control CHANGE fk_project projectid integer;
+ALTER TABLE llx_element_element ADD position INTEGER;
+UPDATE llx_element_element SET sourcetype = 'dolismq_question' WHERE sourcetype = 'question';
+UPDATE llx_element_element SET sourcetype = 'dolismq_sheet' WHERE sourcetype = 'sheet';
+UPDATE llx_element_element SET sourcetype = 'dolismq_control' WHERE sourcetype = 'control';
+UPDATE llx_element_element SET targettype = 'dolismq_question' WHERE targettype = 'question';
+UPDATE llx_element_element SET targettype = 'dolismq_sheet' WHERE targettype = 'sheet';
+UPDATE llx_element_element SET targettype = 'dolismq_control' WHERE targettype = 'control';
 
 -- 1.5.0
-DELETE FROM `llx_document_model` WHERE `nom` =  'calypso';
-ALTER TABLE `llx_dolismq_control` CHANGE `tms` `tms` TIMESTAMP on update CURRENT_TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP;
-ALTER TABLE `llx_dolismq_control` CHANGE `status` `status` INT(11) DEFAULT 1 NOT NULL;
-ALTER TABLE `llx_dolismq_control` CHANGE `import_key` `import_key` VARCHAR(14) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL;
-ALTER TABLE `llx_dolismq_controldet` CHANGE `tms` `tms` TIMESTAMP on update CURRENT_TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP;
-ALTER TABLE `llx_dolismq_controldet` CHANGE `status` `status` INT(11) DEFAULT 1 NOT NULL;
-ALTER TABLE `llx_dolismq_controldet` CHANGE `import_key` `import_key` VARCHAR(14) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL;
-ALTER TABLE `llx_dolismq_dolismqdocuments` CHANGE `tms` `tms` TIMESTAMP on update CURRENT_TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP;
-ALTER TABLE `llx_dolismq_dolismqdocuments` CHANGE `status` `status` INT(11) DEFAULT 1 NOT NULL;
-ALTER TABLE `llx_dolismq_dolismqdocuments` CHANGE `import_key` `import_key` VARCHAR(14) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL;
-ALTER TABLE `llx_dolismq_question` CHANGE `tms` `tms` TIMESTAMP on update CURRENT_TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP;
-ALTER TABLE `llx_dolismq_question` CHANGE `status` `status` INT(11) DEFAULT 1 NOT NULL;
-ALTER TABLE `llx_dolismq_question` CHANGE `import_key` `import_key` VARCHAR(14) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL;
-ALTER TABLE `llx_dolismq_sheet` CHANGE `tms` `tms` TIMESTAMP on update CURRENT_TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP;
-ALTER TABLE `llx_dolismq_sheet` CHANGE `status` `status` INT(11) DEFAULT 1 NOT NULL;
-ALTER TABLE `llx_dolismq_sheet` CHANGE `import_key` `import_key` VARCHAR(14) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL;
+DELETE FROM llx_document_model WHERE nom =  'calypso';
+ALTER TABLE llx_dolismq_control CHANGE tms tms TIMESTAMP on update CURRENT_TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE llx_dolismq_control CHANGE status status INT(11) DEFAULT 1 NOT NULL;
+ALTER TABLE llx_dolismq_control CHANGE import_key import_key VARCHAR(14) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL;
+ALTER TABLE llx_dolismq_controldet CHANGE tms tms TIMESTAMP on update CURRENT_TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE llx_dolismq_controldet CHANGE status status INT(11) DEFAULT 1 NOT NULL;
+ALTER TABLE llx_dolismq_controldet CHANGE import_key import_key VARCHAR(14) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL;
+ALTER TABLE llx_dolismq_dolismqdocuments CHANGE tms tms TIMESTAMP on update CURRENT_TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE llx_dolismq_dolismqdocuments CHANGE status status INT(11) DEFAULT 1 NOT NULL;
+ALTER TABLE llx_dolismq_dolismqdocuments CHANGE import_key import_key VARCHAR(14) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL;
+ALTER TABLE llx_dolismq_question CHANGE tms tms TIMESTAMP on update CURRENT_TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE llx_dolismq_question CHANGE status status INT(11) DEFAULT 1 NOT NULL;
+ALTER TABLE llx_dolismq_question CHANGE import_key import_key VARCHAR(14) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL;
+ALTER TABLE llx_dolismq_sheet CHANGE tms tms TIMESTAMP on update CURRENT_TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE llx_dolismq_sheet CHANGE status status INT(11) DEFAULT 1 NOT NULL;
+ALTER TABLE llx_dolismq_sheet CHANGE import_key import_key VARCHAR(14) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL;
 
 -- 1.6.0
-ALTER TABLE `llx_dolismq_question` CHANGE `label` `label` VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL NOT NULL;
-ALTER TABLE `llx_dolismq_question` CHANGE `type` `type` varchar(128) NOT NULL;
-ALTER TABLE `llx_dolismq_sheet` CHANGE `label` `label` VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL NOT NULL;
-ALTER TABLE `llx_dolismq_answer` CHANGE `pictogram` `pictogram` VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL;
-ALTER TABLE `llx_dolismq_sheet` ADD `description` text AFTER `label`;
-ALTER TABLE `llx_dolismq_question` ADD UNIQUE INDEX uk_dolismq_question_ref (ref, entity);
-ALTER TABLE `llx_dolismq_sheet` ADD UNIQUE INDEX uk_dolismq_sheet_ref (ref, entity);
-ALTER TABLE `llx_dolismq_control` ADD UNIQUE INDEX uk_dolismq_control_ref (ref, entity);
-ALTER TABLE `llx_dolismq_controldet` ADD UNIQUE INDEX uk_dolismq_controldet_ref (ref, entity);
-ALTER TABLE `llx_dolismq_control` ADD `photo` TEXT NULL AFTER `verdict`;
-UPDATE `llx_dolismq_question` SET type = 'OkKoToFixNonApplicable' WHERE type = '';
+ALTER TABLE llx_dolismq_question CHANGE label label VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL NOT NULL;
+ALTER TABLE llx_dolismq_question CHANGE type type varchar(128) NOT NULL;
+ALTER TABLE llx_dolismq_sheet CHANGE label label VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL NOT NULL;
+ALTER TABLE llx_dolismq_answer CHANGE pictogram pictogram VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL;
+ALTER TABLE llx_dolismq_sheet ADD description text AFTER label;
+ALTER TABLE llx_dolismq_question ADD UNIQUE INDEX uk_dolismq_question_ref (ref, entity);
+ALTER TABLE llx_dolismq_sheet ADD UNIQUE INDEX uk_dolismq_sheet_ref (ref, entity);
+ALTER TABLE llx_dolismq_control ADD UNIQUE INDEX uk_dolismq_control_ref (ref, entity);
+ALTER TABLE llx_dolismq_controldet ADD UNIQUE INDEX uk_dolismq_controldet_ref (ref, entity);
+ALTER TABLE llx_dolismq_control ADD photo TEXT NULL AFTER verdict;
+UPDATE llx_dolismq_question SET type = 'OkKoToFixNonApplicable' WHERE type = '';
 
 -- 1.7.0
-ALTER TABLE `llx_dolismq_control` ADD `track_id` VARCHAR(128) NOT NULL AFTER `photo`;
-ALTER TABLE `llx_dolismq_sheet` ADD `mandatory_questions` text AFTER `element_linked`;
-UPDATE `llx_dolismq_question` SET type = 'OkKoToFixNonApplicable' WHERE type IS NULL;
-UPDATE `llx_dolismq_sheet` SET mandatory_questions = '{}' WHERE mandatory_questions IS NULL;
-ALTER TABLE `llx_dolismq_sheet` CHANGE `mandatory_questions` `mandatory_questions` text;
-ALTER TABLE `llx_dolismq_control` ADD `next_control_date` DATETIME AFTER `track_id`;
+ALTER TABLE llx_dolismq_control ADD track_id VARCHAR(128) NOT NULL AFTER photo;
+ALTER TABLE llx_dolismq_sheet ADD mandatory_questions text AFTER element_linked;
+UPDATE llx_dolismq_question SET type = 'OkKoToFixNonApplicable' WHERE type IS NULL;
+UPDATE llx_dolismq_sheet SET mandatory_questions = '{}' WHERE mandatory_questions IS NULL;
+ALTER TABLE llx_dolismq_sheet CHANGE mandatory_questions mandatory_questions text;
+ALTER TABLE llx_dolismq_control ADD next_control_date DATETIME AFTER track_id;
 
 -- 1.8.0
 
-ALTER TABLE `llx_dolismq_answer` RENAME TO `llx_digiquali_answer`;
-ALTER TABLE `llx_dolismq_question` RENAME TO `llx_digiquali_question`;
-ALTER TABLE `llx_dolismq_question_extrafields` RENAME TO `llx_digiquali_question_extrafields`;
-ALTER TABLE `llx_dolismq_sheet` RENAME TO `llx_digiquali_sheet`;
-ALTER TABLE `llx_dolismq_sheet_extrafields` RENAME TO `llx_digiquali_sheet_extrafields`;
-ALTER TABLE `llx_dolismq_control` RENAME TO `llx_digiquali_control`;
-ALTER TABLE `llx_dolismq_control_extrafields` RENAME TO `llx_digiquali_control_extrafields`;
-ALTER TABLE `llx_dolismq_controldet` RENAME TO `llx_digiquali_controldet`;
-ALTER TABLE `llx_dolismq_controldet_extrafields` RENAME TO `llx_digiquali_controldet_extrafields`;
-ALTER TABLE `llx_control_equipment` RENAME TO `llx_digiquali_control_equipment`;
-UPDATE `llx_const` SET name = REPLACE(name, 'DOLISMQ', 'DIGIQUALI') WHERE name LIKE '%DOLISMQ%';
-UPDATE `llx_const` SET value = REPLACE(value, 'dolismq', 'digiquali') WHERE value LIKE '%dolismq%';
-UPDATE `llx_element_element` SET sourcetype = REPLACE(sourcetype, 'dolismq', 'digiquali') WHERE sourcetype LIKE '%dolismq%';
-UPDATE `llx_element_element` SET targettype = REPLACE(targettype, 'dolismq', 'digiquali') WHERE targettype LIKE '%dolismq%';
-DELETE FROM `llx_menu` WHERE module = 'dolismq';
-DELETE FROM `llx_menu` WHERE mainmenu LIKE '%dolismq%';
-UPDATE `llx_rights_def` SET module = 'digiquali' WHERE module = 'dolismq';
-UPDATE `llx_actioncomm` SET elementtype = REPLACE(elementtype, 'dolismq', 'digiquali') WHERE elementtype LIKE '%dolismq%';
-UPDATE `llx_extrafields` SET elementtype = REPLACE(elementtype, 'dolismq', 'digiquali') WHERE elementtype LIKE '%dolismq%';
-UPDATE `llx_extrafields` SET langs = REPLACE(langs, 'dolismq', 'digiquali') WHERE langs LIKE '%dolismq%';
-UPDATE `llx_extrafields` SET enabled = REPLACE(enabled, 'dolismq', 'digiquali') WHERE enabled LIKE '%dolismq%';
-UPDATE `llx_ecm_files` SET filepath = REPLACE(filepath, 'dolismq', 'digiquali') WHERE filepath LIKE '%dolismq%';
-UPDATE `llx_ecm_files` SET src_object_type = REPLACE(src_object_type, 'dolismq', 'digiquali') WHERE src_object_type LIKE '%dolismq%';
-UPDATE `llx_saturne_object_documents` SET ref_ext = REPLACE(ref_ext, 'dolismq', 'digiquali') WHERE ref_ext LIKE '%dolismq%';
-UPDATE `llx_saturne_object_documents` SET module_name = REPLACE(module_name, 'dolismq', 'digiquali') WHERE module_name LIKE '%dolismq%';
-UPDATE `llx_saturne_object_signature` SET module_name = REPLACE(module_name, 'dolismq', 'digiquali') WHERE module_name LIKE '%dolismq%';
-UPDATE `llx_bookmark` SET url = REPLACE(url, 'dolismq', 'digiquali') WHERE url LIKE '%dolismq%';
-UPDATE `llx_ecm_directories` SET label = REPLACE(label, 'dolismq', 'digiquali') WHERE label LIKE '%dolismq%';
-ALTER TABLE `llx_digiquali_control_equipment` ADD `fk_lot` integer AFTER `fk_product`;
-ALTER TABLE `llx_digiquali_control` ADD `control_date` DATETIME AFTER `next_control_date`;
+ALTER TABLE llx_dolismq_answer RENAME TO llx_digiquali_answer;
+ALTER TABLE llx_dolismq_question RENAME TO llx_digiquali_question;
+ALTER TABLE llx_dolismq_question_extrafields RENAME TO llx_digiquali_question_extrafields;
+ALTER TABLE llx_dolismq_sheet RENAME TO llx_digiquali_sheet;
+ALTER TABLE llx_dolismq_sheet_extrafields RENAME TO llx_digiquali_sheet_extrafields;
+ALTER TABLE llx_dolismq_control RENAME TO llx_digiquali_control;
+ALTER TABLE llx_dolismq_control_extrafields RENAME TO llx_digiquali_control_extrafields;
+ALTER TABLE llx_dolismq_controldet RENAME TO llx_digiquali_controldet;
+ALTER TABLE llx_dolismq_controldet_extrafields RENAME TO llx_digiquali_controldet_extrafields;
+ALTER TABLE llx_control_equipment RENAME TO llx_digiquali_control_equipment;
+UPDATE llx_const SET name = REPLACE(name, 'DOLISMQ', 'DIGIQUALI') WHERE name LIKE '%DOLISMQ%';
+UPDATE llx_const SET value = REPLACE(value, 'dolismq', 'digiquali') WHERE value LIKE '%dolismq%';
+UPDATE llx_element_element SET sourcetype = REPLACE(sourcetype, 'dolismq', 'digiquali') WHERE sourcetype LIKE '%dolismq%';
+UPDATE llx_element_element SET targettype = REPLACE(targettype, 'dolismq', 'digiquali') WHERE targettype LIKE '%dolismq%';
+DELETE FROM llx_menu WHERE module = 'dolismq';
+DELETE FROM llx_menu WHERE mainmenu LIKE '%dolismq%';
+UPDATE llx_rights_def SET module = 'digiquali' WHERE module = 'dolismq';
+UPDATE llx_actioncomm SET elementtype = REPLACE(elementtype, 'dolismq', 'digiquali') WHERE elementtype LIKE '%dolismq%';
+UPDATE llx_extrafields SET elementtype = REPLACE(elementtype, 'dolismq', 'digiquali') WHERE elementtype LIKE '%dolismq%';
+UPDATE llx_extrafields SET langs = REPLACE(langs, 'dolismq', 'digiquali') WHERE langs LIKE '%dolismq%';
+UPDATE llx_extrafields SET enabled = REPLACE(enabled, 'dolismq', 'digiquali') WHERE enabled LIKE '%dolismq%';
+UPDATE llx_ecm_files SET filepath = REPLACE(filepath, 'dolismq', 'digiquali') WHERE filepath LIKE '%dolismq%';
+UPDATE llx_ecm_files SET src_object_type = REPLACE(src_object_type, 'dolismq', 'digiquali') WHERE src_object_type LIKE '%dolismq%';
+UPDATE llx_saturne_object_documents SET ref_ext = REPLACE(ref_ext, 'dolismq', 'digiquali') WHERE ref_ext LIKE '%dolismq%';
+UPDATE llx_saturne_object_documents SET module_name = REPLACE(module_name, 'dolismq', 'digiquali') WHERE module_name LIKE '%dolismq%';
+UPDATE llx_saturne_object_signature SET module_name = REPLACE(module_name, 'dolismq', 'digiquali') WHERE module_name LIKE '%dolismq%';
+UPDATE llx_bookmark SET url = REPLACE(url, 'dolismq', 'digiquali') WHERE url LIKE '%dolismq%';
+UPDATE llx_ecm_directories SET label = REPLACE(label, 'dolismq', 'digiquali') WHERE label LIKE '%dolismq%';
+ALTER TABLE llx_digiquali_control_equipment ADD fk_lot integer AFTER fk_product;
+ALTER TABLE llx_digiquali_control ADD control_date DATETIME AFTER next_control_date;
 
 -- 1.10.0
-ALTER TABLE `llx_digiquali_sheet` ADD `photo` TEXT NULL AFTER `element_linked`;
-ALTER TABLE `llx_digiquali_sheet` ADD `success_rate` DOUBLE(24,8) NULL AFTER `photo`;
-ALTER TABLE `llx_digiquali_control` ADD `success_rate` DOUBLE(24,8) NULL AFTER `next_control_date`;
+ALTER TABLE llx_digiquali_sheet ADD photo TEXT NULL AFTER element_linked;
+ALTER TABLE llx_digiquali_sheet ADD success_rate DOUBLE(24,8) NULL AFTER photo;
+ALTER TABLE llx_digiquali_control ADD success_rate DOUBLE(24,8) NULL AFTER next_control_date;
 
 -- 1.11.0
-ALTER TABLE `llx_digiquali_sheet` CHANGE `type` `type` VARCHAR(128) NOT NULL;
-ALTER TABLE `llx_digiquali_survey` ADD `success_rate` DOUBLE(24,8) NULL AFTER `photo`;
+ALTER TABLE llx_digiquali_sheet CHANGE type type VARCHAR(128) NOT NULL;
+ALTER TABLE llx_digiquali_survey ADD success_rate DOUBLE(24,8) NULL AFTER photo;
 
 -- 1.13.0
-ALTER TABLE `llx_digiquali_control` ADD `label` VARCHAR(255) NULL AFTER `status`;
+ALTER TABLE llx_digiquali_control ADD label VARCHAR(255) NULL AFTER status;
 
 -- 20.1.0
-ALTER TABLE `llx_digiquali_question` ADD `json` TEXT NULL AFTER `photo_ko`;
+ALTER TABLE llx_digiquali_question ADD json TEXT NULL AFTER photo_ko;

--- a/view/control/control_card.php
+++ b/view/control/control_card.php
@@ -364,7 +364,7 @@ if ($action == 'create') {
         //FK SHEET
         $objectTypeArray = (!empty(GETPOST('fromtype')) ? saturne_get_objects_metadata(GETPOST('fromtype')) : []);
         $filterType      = (!empty($objectTypeArray) ? dol_strtolower($objectTypeArray['name']) : '');
-        $filter          = 's.type = ' . '"' . $object->element . '" AND s.status = ' . Sheet::STATUS_LOCKED;
+        $filter          = 's.type = \'' . $object->element . '\' AND s.status = ' . Sheet::STATUS_LOCKED;
         $filter         .= (!empty($filterType) ? ' AND s.element_linked LIKE "%' . $filterType . '%"' : '');
         print '<tr><td class="fieldrequired">' . ($source != 'pwa' ? $langs->trans('Sheet') : img_picto('', $sheet->picto . '_2em', 'class="pictofixedwidth"')) . '</td><td>';
         print ($source != 'pwa' ? img_picto('', $sheet->picto, 'class="pictofixedwidth"') : '') . $sheet->selectSheetList(GETPOST('fk_sheet') ?: $sheet->id, 'fk_sheet', $filter, 1);

--- a/view/control/control_equipment.php
+++ b/view/control/control_equipment.php
@@ -187,7 +187,7 @@ if ($id > 0 || !empty($ref)) {
         $productLotFilter['fk_product'] = GETPOST('fk_product');
     }
     if (dol_strlen($excludeFilter) > 0) {
-        $productLotFilter['customsql'] = '`rowid` NOT IN (' . $excludeFilter . ')';
+        $productLotFilter['customsql'] = 'rowid NOT IN (' . $excludeFilter . ')';
     }
 
     $productLots      = saturne_fetch_all_object_type('ProductLot', '', '', 0, 0, $productLotFilter);

--- a/view/survey/survey_card.php
+++ b/view/survey/survey_card.php
@@ -259,7 +259,7 @@ if ($action == 'create') {
 
     //FK SHEET
     print '<tr><td class="fieldrequired">' . $langs->trans('Sheet') . '</td><td>';
-    print img_picto('', $sheet->picto, 'class="pictofixedwidth"') . $sheet->selectSheetList(GETPOST('fk_sheet') ?: $sheet->id, 'fk_sheet', 's.type = ' . '"' . $object->element . '" AND s.status = ' . Sheet::STATUS_LOCKED);
+    print img_picto('', $sheet->picto, 'class="pictofixedwidth"') . $sheet->selectSheetList(GETPOST('fk_sheet') ?: $sheet->id, 'fk_sheet', 's.type = \'' . $object->element . '\' AND s.status = ' . Sheet::STATUS_LOCKED);
     print '<a class="butActionNew" href="' . DOL_URL_ROOT . '/custom/digiquali/view/sheet/sheet_card.php?action=create" target="_blank"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans('AddSheet') . '"></span></a>';
     print '</td></tr>';
 


### PR DESCRIPTION
This merge request fixes a few PostgreSQL incompatibilities that I found when setting up Digiquali.

The main point here is changing strings in SQL, so as to use the standard single-quoting instead of the mysql double-quoting.

On the migration side there is also backtick-quoting for identifiers that is mysql-specific, the standard way being double-quoting.

There is one additional issue fixed around using "user" as a table identifier in some LEFT JOIN queries, which is not possible without double-quoting (ie. marking as an identifier) since "user" is a reserved keyword in postgresql.