### PR TITLE
Fix position null (instead of 1)  when adding the first question or group

### DIFF
--- a/class/sheet.class.php
+++ b/class/sheet.class.php
@@ -521,7 +521,7 @@ class Sheet extends SaturneObject
 
         if ($reindexLast) {
             $sql = 'UPDATE ' . MAIN_DB_PREFIX . 'element_element';
-            $sql .= ' SET position = ( SELECT MAX(position) + 1 FROM llx_element_element WHERE fk_source = '. $this->id .' AND sourcetype = "digiquali_sheet" )';
+            $sql .= ' SET position = ( (SELECT (COALESCE(MAX(position), 0) + 1) FROM llx_element_element WHERE fk_source = '. $this->id .' AND sourcetype = "digiquali_sheet" )';
             $sql .= ' WHERE fk_source = ' . $this->id;
             $sql .= ' AND sourcetype = "digiquali_sheet"';
             $sql .= ' AND (targettype = "digiquali_question" OR targettype = "digiquali_questiongroup")';


### PR DESCRIPTION
position is set to null because `MAX(position)` returns null if there is no existing position found (see https://mariadb.com/docs/server/reference/sql-functions/aggregate-functions/max), but we need it returns 0 to be able to calculate the next position