### PR TITLE
Use textarea for Question Comments Instead of Single-Line Input

### DIFF
--- a/core/tpl/digiquali_question_single.tpl.php
+++ b/core/tpl/digiquali_question_single.tpl.php
@@ -49,7 +49,7 @@ if (!$user->conf->DIGIQUALI_SHOW_ONLY_QUESTIONS_WITH_NO_ANSWER or empty($questio
                 <?php if ($question->enter_comment > 0) : ?>
                     <label class="question__footer-comment">
                         <i class="far fa-comment-dots question-comment-icon"></i>
-                        <input class="question-textarea question-comment" name="comment<?php echo $question->id . "_" . $questionGroupId; ?>" placeholder="<?php echo $langs->transnoentities('WriteComment'); ?>" value="<?php echo $comment; ?>" <?php echo ($object->status == 2 ? 'disabled' : ''); ?>>
+                        <textarea class="question-textarea question-comment" name="comment<?php echo $question->id . "_" . $questionGroupId; ?>" placeholder="<?php echo $langs->transnoentities('WriteComment'); ?>" <?php echo ($object->status == 2 ? 'disabled' : ''); ?>><?php echo $comment; ?></textarea>
                     </label>
                 <?php endif; ?>
                 <?php if ($question->authorize_answer_photo > 0) : ?>


### PR DESCRIPTION
Update the UI to replace the single-line used for entering comments on questions with a <textarea> element. This change improves usability by allowing users to write longer and more readable comments, especially when detailed feedback is needed.
No changes were made to the backend logic; only the frontend input element was modified for a better user experience.

![465382568-8e24f229-0c15-4b15-8865-c6b48165044e](https://github.com/user-attachments/assets/e8b392c4-131c-4d0d-828a-1c4fd797fc25)

<img width="954" height="130" alt="465382741-2c61fe78-a2b0-4dd0-8eef-c1b496d1957a" src="https://github.com/user-attachments/assets/a0656b53-3233-4284-8a9c-411338b2dcbc" />
