### PR TITLE
Fix sql error when class is used by other module

### DIFF
--- a/class/questiongroup.class.php
+++ b/class/questiongroup.class.php
@@ -53,7 +53,7 @@ class QuestionGroup extends SaturneObject
     /**
      * @var int Does object support extrafields ? 0 = No, 1 = Yes
      */
-    public $isextrafieldmanaged = 1;
+    public $isextrafieldmanaged = 0;
 
     /**
      * @var string Name of icon for control. Must be a 'fa-xxx' fontawesome code (or 'fa-xxx_fa_color_size') or 'control@digiquali' if picto is file 'img/object_control.png'


### PR DESCRIPTION
This class has no extrafields table so must have 
$isextrafieldsmanaged to 0 to avoid sql errors.