### PR TITLE
#2344 [DigiQuali] fix: fatal errors on survey_list and questiongroup

### DIFF
--- a/class/actions_digiquali.class.php
+++ b/class/actions_digiquali.class.php
@@ -340,7 +340,7 @@ class ActionsDigiquali
             $this->resprints = $sql;
         }
 
-        if (preg_match('/surveylist|controllist/', $parameters['context'])) {
+        if (preg_match('/\bcontrollist\b/', $parameters['context'])) {
             $sql = ', DATEDIFF(t.next_control_date, CURDATE()) AS days_remaining_before_next_control';
             $this->resprints = $sql;
         }

--- a/class/questiongroup.class.php
+++ b/class/questiongroup.class.php
@@ -420,7 +420,7 @@ class QuestionGroup extends SaturneObject
 	 *
 	 * @return void
 	 */
-	public function initAsSpecimen()
+	public function initAsSpecimen(): void
 	{
 		$this->initAsSpecimenCommon();
 	}


### PR DESCRIPTION
## Changements
- Correction du hook `printFieldListSelect` dans `actions_digiquali.class.php` : le champ `DATEDIFF(t.next_control_date, CURDATE())` était ajouté pour les contextes `surveylist` et `controllist`, alors que `next_control_date` n'existe que dans `llx_digiquali_control`, pas dans `llx_digiquali_survey` → erreur `DB_ERROR_NOSUCHFIELD`
- Correction de `QuestionGroup::initAsSpecimen()` dans `questiongroup.class.php` : ajout du type de retour `: void` pour correspondre à la signature de `SaturneObject::initAsSpecimen(): void` → erreur de déclaration incompatible

## Fichiers modifiés
- `class/actions_digiquali.class.php`
- `class/questiongroup.class.php`

## Issue
#2344
