### PR TITLE
#2347 [Actions] fix: pass int 0 instead of string to shortener fetch()

### DIFF
--- a/class/actions_digiquali.class.php
+++ b/class/actions_digiquali.class.php
@@ -299,7 +299,7 @@ class ActionsDigiquali
             if (isModEnabled('easyurl')) {
                 require_once __DIR__ . '/../../easyurl/class/shortener.class.php';
                 $shortener = new Shortener($this->db);
-                $result    = $shortener->fetch('', '', ' AND t.original_url = \'' . $publicControlInterfaceUrl . '\'');
+                $result    = $shortener->fetch(0, '', ' AND t.original_url = \'' . $publicControlInterfaceUrl . '\'');
                 if ($result > 0) {
                     $publicControlInterfaceUrl = $shortener->short_url;
                 } else {
@@ -520,7 +520,7 @@ class ActionsDigiquali
             if (isModEnabled('easyurl')) {
                 require_once __DIR__ . '/../../easyurl/class/shortener.class.php';
                 $shortener = new Shortener($this->db);
-                $result    = $shortener->fetch('', '', ' AND t.original_url = \'' . $publicControlInterfaceUrl . '\'');
+                $result    = $shortener->fetch(0, '', ' AND t.original_url = \'' . $publicControlInterfaceUrl . '\'');
                 if ($result > 0) {
                     $publicControlInterfaceUrl = $shortener->short_url;
                 } else {


### PR DESCRIPTION
#2347

## Changements
- Correction du TypeError fatal : SaturneObject::fetch() attend un int en premier argument mais recevait une chaine vide
- Remplacement de '' par 0 sur les deux appels a shortener->fetch() (contextes productlotcard et controlcard)

## Fichiers modifies
- class/actions_digiquali.class.php

## Issue
#2347