### PR TITLE
#2352 [Survey] fix: initialize objectsMetadata cache in printFieldListSearch

### DIFF
--- a/class/actions_digiquali.class.php
+++ b/class/actions_digiquali.class.php
@@ -389,8 +389,12 @@ class ActionsDigiquali
         }
 
         if (preg_match('/surveylist|controllist/', $parameters['context'])) {
+            if (!isset($conf->cache['objectsMetadata']) || empty($conf->cache['objectsMetadata'])) {
+                require_once __DIR__ . '/../../saturne/lib/object.lib.php';
+                $conf->cache['objectsMetadata'] = saturne_get_objects_metadata();
+            }
             $objectsMetadata = $conf->cache['objectsMetadata'];
-            foreach($objectsMetadata as $objectMetadata) {
+            foreach ($objectsMetadata as $objectMetadata) {
                 if ($objectMetadata['conf'] == 0) {
                     continue;
                 }


### PR DESCRIPTION
#2352

## Changements
- Initialisation du cache objectsMetadata dans printFieldListSearch quand il est vide
- Evite un foreach sur null (Warning PHP) et une requete SQL invalide avec t.fk_productlot (champ inexistant)
- La methode utilise desormais le meme pattern d'initialisation que les autres methodes de la classe

## Contexte
Sur la page survey_list.php?fromtype=productlot&fromid=5, deux erreurs apparaissaient :
1. Warning: Invalid argument supplied for foreach() - conf->cache['objectsMetadata'] etait null
2. DB_ERROR_NOSUCHFIELD sur t.fk_productlot - sans le cache, le hook retournait 0 et la generation SQL standard produisait t.fk_productlot IN (5) au lieu de ee.fk_source IN (5)

## Fichiers modifies
- class/actions_digiquali.class.php