### PR TITLE
Fix: erreur de syntaxe SQL pour la table llx_digiquali_controldet

### DIFF
--- a/sql/control/llx_digiquali_controldet.sql
+++ b/sql/control/llx_digiquali_controldet.sql
@@ -29,5 +29,5 @@ CREATE TABLE llx_digiquali_controldet(
 	fk_user_creat     integer NOT NULL,
 	fk_user_modif     integer,
 	fk_control        integer NOT NULL,
-	fk_question       integer,
+	fk_question       integer
 ) ENGINE=innodb;


### PR DESCRIPTION
Résout l'issue #2358. Retire la virgule en trop empêchant l'installation de la table.