### PR TITLE
Fix: Tasks duplicating across questions due to loop inheritance (#2363)

### DIFF
--- a/core/tpl/digiquali_answers.tpl.php
+++ b/core/tpl/digiquali_answers.tpl.php
@@ -29,6 +29,10 @@
  */
 
 foreach ($questionsAndGroups as $questionOrGroup) {
+    if (!isset($objectLineClass) && is_object($objectLine)) {
+        $objectLineClass = get_class($objectLine);
+    }
+    
     $questionAnswer = '';
     $comment        = '';
 
@@ -66,12 +70,15 @@ foreach ($questionsAndGroups as $questionOrGroup) {
         if (is_array($groupQuestions) && !empty($groupQuestions)) {
             print '<div class="group-questions">';
             foreach ($groupQuestions as $question) {
-                $result = $objectLine->fetchFromParentWithQuestion($object->id, $question->id);
+                $tmpObjectLine = new $objectLineClass($object->db);
+                $result = $tmpObjectLine->fetchFromParentWithQuestion($object->id, $question->id);
                 if (is_array($result) && !empty($result)) {
                     $objectLine = array_shift($result);
                     $questionAnswer = $objectLine->answer;
                     $comment = $objectLine->comment;
                     $objectLine->fetchObjectLinked($objectLine->id, $objectLine->element);
+                } else {
+                    $objectLine = clone $tmpObjectLine;
                 }
 
                 $question = $question;
@@ -83,12 +90,15 @@ foreach ($questionsAndGroups as $questionOrGroup) {
 
         print '</div>';
     } else {
-        $result = $objectLine->fetchFromParentWithQuestion($object->id, $questionOrGroup->id);
+        $tmpObjectLine = new $objectLineClass($object->db);
+        $result = $tmpObjectLine->fetchFromParentWithQuestion($object->id, $questionOrGroup->id);
         if (is_array($result) && !empty($result)) {
             $objectLine = array_shift($result);
             $questionAnswer = $objectLine->answer;
             $comment = $objectLine->comment;
             $objectLine->fetchObjectLinked($objectLine->id, $objectLine->element);
+        } else {
+            $objectLine = clone $tmpObjectLine;
         }
         $question = $questionOrGroup;
 


### PR DESCRIPTION
Resolves #2363.

**Cause:**
Inside digiquali_answers.tpl.php, if a question did not have an existing answer in the database, etchFromParentWithQuestion returned empty. The previous iterations $objectLine was subsequently kept in memory and passed to digiquali_question_single.tpl.php, causing its linked objects (like tasks, comments, etc.) to visually leak into the unanswered question on the interface.

**Fix:**
Dynamically instantiated a clean $objectLine context inside the question loop using get_class(). If the DB fetch yields no result, we now strictly assign an empty $tmpObjectLine to $objectLine to ensure isolation between questions.