### PR TITLE
#2374 [DigiQuali] fix: update getTriggerDescription signature to match SaturneObject

### DIFF
--- a/class/activity.class.php
+++ b/class/activity.class.php
@@ -183,15 +183,16 @@ class Activity extends SaturneObject
     /**
      * Write information of trigger description
      *
-     * @return string Description to display in actioncomm->note_private
+     * @param  SaturneObject $object Object to describe
+     * @return string                Description to display in actioncomm->note_private
      */
-    public function getTriggerDescription(): string
+    public function getTriggerDescription(SaturneObject $object): string
     {
         global $langs;
 
         $linkedElement = json_decode($this->element_linked, true);
 
-        $ret  = parent::getTriggerDescription();
+        $ret  = parent::getTriggerDescription($object);
         $ret .= $langs->transnoentities('ElementLinked') . ' : ';
 
         if (is_array($linkedElement) && !empty($linkedElement)) {

--- a/class/answer.class.php
+++ b/class/answer.class.php
@@ -251,13 +251,14 @@ class Answer extends SaturneObject
     /**
      * Write information of trigger description
      *
-     * @return string Description to display in actioncomm->note_private
+     * @param  SaturneObject $object Object to describe
+     * @return string                Description to display in actioncomm->note_private
      */
-    public function getTriggerDescription(): string
+    public function getTriggerDescription(SaturneObject $object): string
     {
         global $db, $langs;
 
-        $ret   = parent::getTriggerDescription();
+        $ret   = parent::getTriggerDescription($object);
         $ret  .= $langs->transnoentities('Position') . ' : ' . $this->position . '</br>';
         $ret  .= $langs->transnoentities('Color') . ' : ' . $this->color . '</br>';
         $ret  .= (dol_strlen($this->pictogram) > 0 ? $langs->transnoentities('Pictogram') . ' : ' . $this->pictogram . '</br>' : '');

--- a/class/control.class.php
+++ b/class/control.class.php
@@ -1170,9 +1170,10 @@ class Control extends SaturneObject
     /**
      * Write information of trigger description
      *
-     * @return string Description to display in actioncomm->note_private
+     * @param  SaturneObject $object Object to describe
+     * @return string                Description to display in actioncomm->note_private
      */
-    public function getTriggerDescription(): string
+    public function getTriggerDescription(SaturneObject $object): string
     {
         global $db, $langs;
 
@@ -1182,7 +1183,7 @@ class Control extends SaturneObject
         $sheet = new Sheet($db);
         $sheet->fetch($this->fk_sheet);
 
-        $ret  = parent::getTriggerDescription();
+        $ret  = parent::getTriggerDescription($object);
         $ret .= $langs->transnoentities('Sheet') . ' : ' . $sheet->ref . ' - ' . $sheet->label . '<br>';
         if ($this->fk_user_controller > 0) {
             $user = new User($db);

--- a/class/question.class.php
+++ b/class/question.class.php
@@ -673,13 +673,14 @@ class Question extends SaturneObject
 	/**
 	 * Write information of trigger description
 	 *
-	 * @return string Description to display in actioncomm->note_private
+	 * @param  SaturneObject $object Object to describe
+	 * @return string                Description to display in actioncomm->note_private
 	 */
-	public function getTriggerDescription(): string
+	public function getTriggerDescription(SaturneObject $object): string
 	{
 		global $langs;
 
-		$ret   = parent::getTriggerDescription();
+		$ret   = parent::getTriggerDescription($object);
 		$ret  .= $langs->transnoentities('ShowPhoto') . ' : ' . ($this->show_photo ? $langs->transnoentities('Yes') : $langs->transnoentities('No')) . '</br>';
 		$ret  .= $langs->transnoentities('AuthorizeAnswerPhoto') . ' : ' . ($this->authorize_answer_photo ? $langs->transnoentities('Yes') : $langs->transnoentities('No')) . '</br>';
 		$ret  .= $langs->transnoentities('EnterComment') . ' : ' . ($this->enter_comment ? $langs->transnoentities('Yes') : $langs->transnoentities('No')) . '</br>';

--- a/class/riskassessment.class.php
+++ b/class/riskassessment.class.php
@@ -183,15 +183,16 @@ class RiskAssessment extends SaturneObject
     /**
      * Write information of trigger description
      *
-     * @return string Description to display in actioncomm->note_private
+     * @param  SaturneObject $object Object to describe
+     * @return string                Description to display in actioncomm->note_private
      */
-    public function getTriggerDescription(): string
+    public function getTriggerDescription(SaturneObject $object): string
     {
         global $langs;
 
         $linkedElement = json_decode($this->element_linked, true);
 
-        $ret  = parent::getTriggerDescription();
+        $ret  = parent::getTriggerDescription($object);
         $ret .= $langs->transnoentities('ElementLinked') . ' : ';
 
         if (is_array($linkedElement) && !empty($linkedElement)) {

--- a/class/sheet.class.php
+++ b/class/sheet.class.php
@@ -662,15 +662,16 @@ class Sheet extends SaturneObject
 	/**
 	 * Write information of trigger description
 	 *
-	 * @return string Description to display in actioncomm->note_private
+	 * @param  SaturneObject $object Object to describe
+	 * @return string                Description to display in actioncomm->note_private
 	 */
-	public function getTriggerDescription(): string
+	public function getTriggerDescription(SaturneObject $object): string
 	{
 		global $langs;
 
 		$linkedElement = json_decode($this->element_linked, true);
 
-		$ret  = parent::getTriggerDescription();
+		$ret  = parent::getTriggerDescription($object);
 		$ret .= $langs->transnoentities('ElementLinked') . ' : ';
 
 		if (is_array($linkedElement) && !empty($linkedElement)) {

--- a/class/survey.class.php
+++ b/class/survey.class.php
@@ -634,9 +634,10 @@ class Survey extends SaturneObject
     /**
      * Write generic information of trigger description
      *
-     * @return string Description to display in actioncomm->note_private
+     * @param  SaturneObject $object Object to describe
+     * @return string                Description to display in actioncomm->note_private
      */
-    public function getTriggerDescription(): string
+    public function getTriggerDescription(SaturneObject $object): string
     {
         global $langs;
 
@@ -646,7 +647,7 @@ class Survey extends SaturneObject
         $sheet = new Sheet($this->db);
         $sheet->fetch($this->fk_sheet);
 
-        $ret  = parent::getTriggerDescription();
+        $ret  = parent::getTriggerDescription($object);
         $ret .= $langs->transnoentities('Sheet') . ' : ' . $sheet->ref . ' - ' . $sheet->label . '</br>';
         if ($this->projectid > 0) {
             require_once DOL_DOCUMENT_ROOT . '/projet/class/project.class.php';

--- a/core/triggers/interface_99_modDigiQuali_DigiQualiTriggers.class.php
+++ b/core/triggers/interface_99_modDigiQuali_DigiQualiTriggers.class.php
@@ -88,7 +88,7 @@ class InterfaceDigiQualiTriggers extends DolibarrTriggers
         if (getDolGlobalInt('DIGIQUALI_ADVANCED_TRIGGER') === 1 &&
             method_exists($object, 'getTriggerDescription') &&
             !empty($object->fields)) {
-            $actionComm->note_private = $object->getTriggerDescription();
+            $actionComm->note_private = $object->getTriggerDescription($object);
         }
 
         $objects = [


### PR DESCRIPTION
## Changements
- Mise a jour de la signature de getTriggerDescription() dans toutes les classes DigiQuali pour correspondre a la nouvelle signature SaturneObject::getTriggerDescription(SaturneObject object)
- Correction de l'appel dans le trigger qui causait un Fatal error Too few arguments
- Propagation du parametre object aux appels parent::getTriggerDescription(object) dans toutes les sous-classes

## Fichiers modifies
- class/activity.class.php
- class/answer.class.php
- class/control.class.php
- class/question.class.php
- class/riskassessment.class.php
- class/sheet.class.php
- class/survey.class.php
- core/triggers/interface_99_modDigiQuali_DigiQualiTriggers.class.php

## Issue
#2374