### PR TITLE
#2365 [Sheet] fix: count questions in groups for sheet list

### DIFF
--- a/class/actions_digiquali.class.php
+++ b/class/actions_digiquali.class.php
@@ -929,11 +929,8 @@ class ActionsDigiquali
             $out = [];
 
             if ($parameters['key'] == 'nb_questions') {
-                $out[$parameters['key']]  = 0;
-                $object->fetchObjectLinked($object->id, 'digiquali_' . $object->element, null, '', 'OR', 1, 'position', 0);
-                if (isset($object->linkedObjectsIds['digiquali_question']) && is_array($object->linkedObjectsIds['digiquali_question'])) {
-                    $out[$parameters['key']] = count($object->linkedObjectsIds['digiquali_question']);
-                }
+                $allQuestions               = $object->fetchAllQuestions();
+                $out[$parameters['key']]    = is_array($allQuestions) ? count($allQuestions) : 0;
             }
 
             if ($parameters['key'] == 'photo') {


### PR DESCRIPTION
## Changements
- Correction du comptage du nombre de questions dans la liste des modèles (sheet list)
- Le comptage utilisait fetchObjectLinked qui ne remontait que les questions directement liées au sheet, ignorant celles imbriquées dans des groupes de questions
- Remplacement par fetchAllQuestions() qui parcourt récursivement les groupes pour retourner toutes les questions

## Fichiers modifiés
- class/actions_digiquali.class.php

## Issue
#2365
