### PR TITLE
#2285 [DigiQualiElement] fix: add commonfields_view to display description

### DIFF
--- a/view/digiqualielement/digiqualielement_card.php
+++ b/view/digiqualielement/digiqualielement_card.php
@@ -306,6 +306,9 @@ if ((empty($action) || ($action != 'edit' && $action != 'create'))) {
     print saturne_show_medias_linked('digiriskdolibarr', $conf->digiriskdolibarr->multidir_output[$conf->entity] . '/' . $object->element_type . '/' . $object->ref, 'small', 5, 0, 0, 0, 50, 50, 0, 0, 0, $object->element_type . '/'. $object->ref . '/', $object, 'photo', $object->status != $object::STATUS_VALIDATED, $permissiontodelete && $object->status != $object::STATUS_VALIDATED);
     print '</td></tr>';
 
+    // Common attributes
+    require_once DOL_DOCUMENT_ROOT . '/core/tpl/commonfields_view.tpl.php';
+
     // Other attributes. Fields from hook formObjectOptions and Extrafields
     require_once DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_view.tpl.php';
 


### PR DESCRIPTION
Ajout de commonfields_view.tpl.php dans la vue de la fiche processus/sous-processus. Le champ description etait sauvegarde mais jamais affiche en mode vue. Fix issue #2285