### PR TITLE
#2378 [DigiQualiElement] fix: add prefix key to element_type field for button labels

### DIFF
--- a/class/digiqualielement.class.php
+++ b/class/digiqualielement.class.php
@@ -52,5 +52,6 @@ class DigiQualiElement extends SaturneElement
         parent::__construct($db, $this->module, $this->element);
 
         $this->fields['element_type']['arrayofkeyval'] = [0 => 'Process', 1 => 'SubProcess'];
+        $this->fields['element_type']['prefix']       = [0 => 'P', 1 => 'SP'];
     }
 }


### PR DESCRIPTION
Fix boutons P et SP sans texte dans la cartographie. La cle prefix manquait dans DigiQualiElement. Fix issue #2378