### PR TITLE
#373 [RegistrationCertificate] fix: reorder lot display to CG-VIN-vehicle type

### DIFF
--- a/view/control/control_card.php
+++ b/view/control/control_card.php
@@ -492,9 +492,15 @@ if ($action == 'create') {
                                 $registrationCertificatesList = $registrationCertificate->fetchAll('', '', 0, 0, ['customsql' => 'fk_lot = ' . ((int) $objectSingle->id)]);
                                 if (is_array($registrationCertificatesList) && !empty($registrationCertificatesList)) {
                                     $registrationCertificate = reset($registrationCertificatesList);
+                                    $parts = [];
                                     if (!empty($registrationCertificate->a_registration_number)) {
-                                        $objectName .= ' - ' . $registrationCertificate->a_registration_number;
+                                        $parts[] = $registrationCertificate->a_registration_number;
                                     }
+                                    if (!empty($registrationCertificate->e_vehicle_serial_number)) {
+                                        $parts[] = $registrationCertificate->e_vehicle_serial_number;
+                                    }
+                                    $parts[]    = $product->ref;
+                                    $objectName = implode(' - ', $parts);
                                 }
                             }
                         } else {


### PR DESCRIPTION
## Changements
- Reordonnancement de l'affichage du lot produit lie a une carte grise lors de la creation d'un controle
- Nouvel ordre : CG (immatriculation) - VIN (e_vehicle_serial_number) - Type de vehicule (ref produit)
- Ajout du VIN qui n'etait pas affiche
- Les parties vides sont omises automatiquement

## Fichiers modifies
- view/control/control_card.php

## Issue
Evarisk/dolicar#373