### PR TITLE
#2383 [Survey] fix: guard fetch in getTriggerDescription

### DIFF
--- a/class/survey.class.php
+++ b/class/survey.class.php
@@ -643,11 +643,13 @@ class Survey extends SaturneObject
         // Load DigiQuali libraries
         require_once __DIR__ . '/../class/sheet.class.php';
 
-        $sheet = new Sheet($this->db);
-        $sheet->fetch($this->fk_sheet);
-
-        $ret  = parent::getTriggerDescription();
-        $ret .= $langs->transnoentities('Sheet') . ' : ' . $sheet->ref . ' - ' . $sheet->label . '</br>';
+        $ret = parent::getTriggerDescription();
+        if ($this->fk_sheet > 0) {
+            $sheet = new Sheet($this->db);
+            if ($sheet->fetch($this->fk_sheet) > 0) {
+                $ret .= $langs->transnoentities('Sheet') . ' : ' . $sheet->ref . ' - ' . $sheet->label . '</br>';
+            }
+        }
         if ($this->projectid > 0) {
             require_once DOL_DOCUMENT_ROOT . '/projet/class/project.class.php';
             $project = new Project($this->db);


### PR DESCRIPTION
Closes #2383

## Summary

`Survey::getTriggerDescription()` instanciait un `Sheet`, appelait `fetch()` sans vérifier le retour, puis lisait `$sheet->ref` et `$sheet->label`. `Sheet::$label` étant une propriété typée non nullable sans valeur par défaut, un fetch raté (par ex. `fk_sheet` vide ou ligne absente) provoquait un fatal PHP `Typed property Sheet::$label must not be accessed before initialization` au premier trigger Survey (vu sur `SURVEY_CREATE`).

Le bloc Sheet est désormais conditionné à `fk_sheet > 0` et au succès du `fetch()`, sur le même modèle que le bloc Project juste en dessous.

## Test plan

- [ ] Créer un Survey avec une `fk_sheet` valide → trigger `SURVEY_CREATE` ne crashe plus, la note privée de l'actioncomm contient bien `Sheet : <ref> - <label>`.
- [ ] Créer/modifier un Survey avec une `fk_sheet` vide ou pointant vers une sheet supprimée → plus de fatal, la ligne Sheet est simplement omise de la note privée.
- [ ] Vérifier les autres triggers Survey (`SURVEY_MODIFY`, `SURVEY_VALIDATE`, `SURVEY_DELETE`, etc.) : pas de régression.