### PR TITLE
#2380 [Question] add: auto-generate nf question categories on module init

### DIFF
--- a/core/modules/modDigiQuali.class.php
+++ b/core/modules/modDigiQuali.class.php
@@ -205,6 +205,7 @@ class modDigiQuali extends DolibarrModules
 			$i++ => ['DIGIQUALI_QUESTION_ADDON', 'chaine', 'mod_question_standard', '', 0, 'current'],
 			$i++ => ['DIGIQUALI_QUESTIONGROUP_ADDON', 'chaine', 'mod_questiongroup_standard', '', 0, 'current'],
             $i++ => ['DIGIQUALI_QUESTION_BACKWARD_COMPATIBILITY', 'integer', 1, '', 0, 'current'],
+			$i++ => ['DIGIQUALI_QUESTION_NF_TAGS_SET', 'integer', 0, '', 0, 'current'],
 
 			// CONST ANSWER
 			$i++ => ['DIGIQUALI_ANSWER_ADDON', 'chaine', 'mod_answer_standard', '', 0, 'current'],
@@ -877,6 +878,17 @@ class modDigiQuali extends DolibarrModules
 			$tags->create($user);
 
 			dolibarr_set_const($this->db, 'DIGIQUALI_SHEET_DEFAULT_TAG', $tags->id, 'integer', 0, '', $conf->entity);
+		}
+
+		if (empty($conf->global->DIGIQUALI_QUESTION_NF_TAGS_SET)) {
+			require_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';
+
+			$nfParentId = saturne_create_category($langs->transnoentities('NF'), 'question');
+			saturne_create_category($langs->transnoentities('NFSysteme'), 'question', $nfParentId);
+			saturne_create_category($langs->transnoentities('NFPoste'),   'question', $nfParentId);
+			saturne_create_category($langs->transnoentities('NFProduit'), 'question', $nfParentId);
+
+			dolibarr_set_const($this->db, 'DIGIQUALI_QUESTION_NF_TAGS_SET', 1, 'integer', 0, '', $conf->entity);
 		}
         // Create extrafields during init.
         include_once DOL_DOCUMENT_ROOT . '/core/class/extrafields.class.php';

--- a/langs/fr_FR/digiquali.lang
+++ b/langs/fr_FR/digiquali.lang
@@ -678,3 +678,12 @@ ControlObservationList  = Liste des points contrôlés, observations et réponse
 LinkedContactsControl   = Contact(s) associés au contrôle
 LinkedControllerControl = Contrôleur(s) associés au contrôle
 NoEquipmentFound        = Aucun équipement trouvé.
+
+#
+# Question categories - NF
+#
+
+NF        = NF
+NFSysteme = Système
+NFPoste   = Poste
+NFProduit = Produit


### PR DESCRIPTION
#2380

## Changements
- Ajout de la constante DIGIQUALI_QUESTION_NF_TAGS_SET dans le tableau des constantes du module
- Lors de l'activation ou la mise a jour du module, creation automatique de la hierarchie de categories NF pour les questions : NF -> Systeme / Poste / Produit
- La constante est passee a 1 apres creation pour eviter les doublons lors des reinitialisations suivantes
- Ajout des traductions NF, NFSysteme, NFPoste, NFProduit

## Fichiers modifies
- core/modules/modDigiQuali.class.php
- langs/fr_FR/digiquali.lang