### PR TITLE
#2391 [DigiQuali] remove: control tab from commercial proposals

### DIFF
--- a/core/modules/modDigiQuali.class.php
+++ b/core/modules/modDigiQuali.class.php
@@ -327,7 +327,9 @@ class modDigiQuali extends DolibarrModules
             } else {
                 $objectType = $objectMetadata['tab_type'];
             }
-            $this->tabs[] = ['data' => $objectType . ':+control:' . $pictoDigiQuali . $langs->trans('Controls') . ':digiquali@digiquali:$user->rights->digiquali->control->read:/custom/digiquali/view/control/control_list.php?fromid=__ID__&fromtype=' . $objectMetadata['link_name']];
+            if ($objectMetadata['link_name'] !== 'propal') {
+                $this->tabs[] = ['data' => $objectType . ':+control:' . $pictoDigiQuali . $langs->trans('Controls') . ':digiquali@digiquali:$user->rights->digiquali->control->read:/custom/digiquali/view/control/control_list.php?fromid=__ID__&fromtype=' . $objectMetadata['link_name']];
+            }
             $this->tabs[] = ['data' => $objectType . ':+survey:' . $pictoDigiQuali . $langs->trans('Surveys') . ':digiquali@digiquali:$user->rights->digiquali->survey->read:/custom/digiquali/view/survey/survey_list.php?fromid=__ID__&fromtype=' . $objectMetadata['link_name']];
 
             $this->module_parts['hooks'][] = $objectMetadata['hook_name_list'];


### PR DESCRIPTION
## Changements
- Suppression de l'onglet **Controls** sur les Propositions commerciales (propal)
- L'onglet **Surveys** reste présent sur les propals
- Les autres objets Dolibarr conservent les deux onglets inchangés

## Fichiers modifiés
- core/modules/modDigiQuali.class.php

## Issue
#2391
