### PR TITLE
#2394 [QuestionGroup] fix: accept SaturneObject instead of Survey in isCorrect

### DIFF
--- a/class/questiongroup.class.php
+++ b/class/questiongroup.class.php
@@ -795,7 +795,7 @@ class QuestionGroup extends SaturneObject
 	 *
 	 * @return bool
 	 */
-	public function isCorrect(Survey $survey): bool
+	public function isCorrect(SaturneObject $survey): bool
 	{
 
         [$numberOfAnsweredQuestions, $numberOfQuestions, $correctPoints, $totalPoints, $atLeastOneIncorrectSubGroup] = $this->calculatePoints($survey);
@@ -830,11 +830,11 @@ class QuestionGroup extends SaturneObject
      * Return a array of formatted string to print group score (in points)
      * and success rate
      *
-     * @param Survey $survey the survey on which check answers are correct or not
+     * @param SaturneObject $survey the object on which check answers are correct or not
      *
      * @return array
 	 */
-    public function getFormattedSuccessPointsAndRates(Survey $survey): array
+    public function getFormattedSuccessPointsAndRates(SaturneObject $survey): array
 	{
         global $langs;
 


### PR DESCRIPTION
#2394

## Changements

- Correction du type hint de `isCorrect()` : `Survey` -> `SaturneObject`
- Correction du type hint de `getFormattedSuccessPointsAndRates()` : `Survey` -> `SaturneObject`
- `calculatePoints()` utilisait deja `SaturneObject`, les deux autres methodes sont maintenant coherentes

## Cause

Fatal error lors de l appel depuis `digiquali_answers.tpl.php` avec un objet `Control` : les deux classes `Control` et `Survey` etendent `SaturneObject` mais seule `Survey` etait acceptee.

## Fichiers modifies

- `class/questiongroup.class.php`

## Issue
#2394