### PR TITLE
#2398 [Control] feat: integrate saturne_render_media_block in control card and questions

### DIFF
--- a/core/modules/digiquali/digiqualidocuments/controldocument/doc_controldocument_odt.modules.php
+++ b/core/modules/digiquali/digiqualidocuments/controldocument/doc_controldocument_odt.modules.php
@@ -375,7 +375,7 @@ class doc_controldocument_odt extends SaturneDocumentModel
         $object = $moreParam['object'];
 
         if (!empty($object->photo)) {
-            $path       = $conf->digiquali->multidir_output[$conf->entity] . '/control/' . $object->ref . '/photos';
+            $path       = $conf->digiquali->multidir_output[$conf->entity] . '/control/' . $object->id . '/photos';
             $thumb_name = saturne_get_thumb_name($object->photo, 'small');
             $image      = $path . '/thumbs/' . $thumb_name;
             $tmpArray['photoDefault'] = $image;

--- a/core/modules/digiquali/digiqualidocuments/controldocument/pdf_controldocument.modules.php
+++ b/core/modules/digiquali/digiqualidocuments/controldocument/pdf_controldocument.modules.php
@@ -411,7 +411,7 @@ class pdf_controldocument extends SaturneDocumentModel
         // Photo block
         if (!empty($control->photo)) {
             $multdir = getMultidirOutput($control, $control->module);
-            $path    = $multdir . '/control/' . $control->ref . '/photos';
+            $path    = $multdir . '/control/' . $control->id . '/photos';
             $thumb   = saturne_get_thumb_name($control->photo, 'medium', $path);
             $image   = $path . '/thumbs/' . $thumb;
             if (file_exists($image)) {

--- a/core/tpl/digiquali_question_single.tpl.php
+++ b/core/tpl/digiquali_question_single.tpl.php
@@ -67,22 +67,11 @@ if (!isset($user->conf->DIGIQUALI_SHOW_ONLY_QUESTIONS_WITH_NO_ANSWER) || empty($
                 <?php endif; ?>
                 <?php if ($question->authorize_answer_photo > 0) : ?>
                     <div class="question__footer-linked-medias">
-                        <div class="linked-medias linked-medias-list answer_photo_<?php echo $question->id ?>">
-                            <?php if ($object->status == 0) : ?>
-                                <input hidden multiple class="fast-upload<?php echo getDolGlobalInt('SATURNE_USE_FAST_UPLOAD_IMPROVEMENT') ? '-improvement' : ''; ?>" id="fast-upload-answer-photo<?php echo $question->id ?>" type="file" name="userfile[]" capture="environment" accept="image/*">
-                                <input type="hidden" class="question-answer-photo" id="answer_photo_<?php echo $question->id ?>" name="answer_photo_<?php echo $question->id ?>" value=""/>
-                                <input type="hidden" class="fast-upload-options" data-from-subtype="answer_photo_<?php echo $question->id ?>" data-from-subdir="answer_photo/<?php echo $question->ref ?>"/>
-                                <label for="fast-upload-answer-photo<?php echo $question->id ?>">
-                                    <div class="wpeo-button button-square-50">
-                                        <i class="fas fa-camera"></i><i class="fas fa-plus-circle button-add"></i>
-                                    </div>
-                                </label>
-                                <div class="wpeo-button button-square-50 open-media-gallery add-media modal-open" value="<?php echo $question->id ?>">
-                                    <input type="hidden" class="modal-options" data-modal-to-open="media_gallery" data-from-id="<?php echo $object->id ?>" data-from-type="<?php echo $object->element ?>" data-from-subtype="answer_photo_<?php echo $question->id ?>" data-from-subdir="answer_photo/<?php echo $question->ref ?>"/>
-                                    <i class="fas fa-folder-open"></i><i class="fas fa-plus-circle button-add"></i>
-                                </div>
-                            <?php endif; ?>
-                        </div>
+                        <?php echo saturne_render_media_block('digiquali', $object->element . '/' . $object->ref . '/answer_photo/' . $question->ref, 'answer_photo_' . $question->id, '', [
+                            'show_photo'  => true,
+                            'show_audio'  => false,
+                            'show_upload' => $object->status == 0,
+                        ]); ?>
                     </div>
                 <?php endif; ?>
                 <?php if (!empty($object->project) && !empty($permissionToAddTask)) : ?>
@@ -99,11 +88,7 @@ if (!isset($user->conf->DIGIQUALI_SHOW_ONLY_QUESTIONS_WITH_NO_ANSWER) || empty($
                 }
                 ?>
             </div>
-            <?php if ($question->authorize_answer_photo > 0) : ?>
-                <div class="question__list-medias">
-                    <?php echo saturne_show_medias_linked('digiquali', $conf->digiquali->multidir_output[$conf->entity] . '/' . $object->element . '/' . $object->ref . '/answer_photo/' . $question->ref, 'small', '', 0, 0, 0, 50, 50, 0, 0, 0, $object->element . '/' . $object->ref . '/answer_photo/' . $question->ref, $question, '', 0, $object->status == 0, 1); ?>
-                </div>
-            <?php endif;
+            <?php
             if (!empty($permissionToReadTask)) :
                 require __DIR__ . '/answers/answers_task_view.tpl.php';
             endif; ?>

--- a/css/scss/page/answer/_answer.scss
+++ b/css/scss/page/answer/_answer.scss
@@ -331,18 +331,16 @@
         }
       }
 
-      .linked-medias {
-        gap: 1px;
-        width: 101px;
-        margin-bottom: 0;
+      .question__footer-linked-medias {
+        flex-shrink: 0;
 
-        label .wpeo-button {
-          border-top-right-radius: 0;
-          border-bottom-right-radius: 0;
+        .linked-medias {
+          gap: 0;
+          margin-bottom: 0;
         }
-        .open-media-gallery {
-          border-top-left-radius: 0;
-          border-bottom-left-radius: 0;
+
+        .saturne-media-upload-block {
+          gap: 4px;
         }
       }
       .add-action {

--- a/view/control/control_card.php
+++ b/view/control/control_card.php
@@ -43,6 +43,7 @@ require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/functions2.lib.php';
 
 // Load Saturne libraries.
+require_once __DIR__ . '/../../../saturne/lib/medias.lib.php';
 require_once __DIR__ . '/../../../saturne/class/saturnesignature.class.php';
 require_once __DIR__ . '/../../../saturne/class/task/saturnetask.class.php';
 
@@ -293,6 +294,50 @@ if (empty($resHook)) {
                 // Set reopened KO
                 if (!empty($object->errors)) setEventMessages(null, $object->errors, 'errors');
                 else setEventMessages($object->error, null, 'errors');
+            }
+        }
+    }
+
+    // Action to upload a photo via the media block AJAX upload
+    if ($action == 'uploadPhoto' && !empty($conf->global->MAIN_UPLOAD_DOC)) {
+        $uploadModuleName = GETPOST('module_name', 'alpha');
+        $uploadSubDir     = GETPOST('sub_dir', 'alpha');
+
+        if (!empty($uploadModuleName)) {
+            $uploadModuleNameLowerCase = dol_strtolower($uploadModuleName);
+            $uploadDir                = !empty($conf->$uploadModuleNameLowerCase->dir_output)
+                ? $conf->$uploadModuleNameLowerCase->dir_output
+                : $conf->ecm->dir_output . '/' . $uploadModuleNameLowerCase;
+            if (!empty($uploadSubDir)) {
+                $uploadDir .= '/' . $uploadSubDir;
+            }
+
+            if (!dol_is_dir($uploadDir)) {
+                dol_mkdir($uploadDir);
+            }
+
+            $uploadedFiles = isset($_FILES['userfile']) ? $_FILES['userfile'] : [];
+            $invalidFile   = false;
+            if (!empty($uploadedFiles['tmp_name'])) {
+                $tmpNames = is_array($uploadedFiles['tmp_name']) ? $uploadedFiles['tmp_name'] : [$uploadedFiles['tmp_name']];
+                foreach ($tmpNames as $tmpName) {
+                    if (empty($tmpName)) {
+                        continue;
+                    }
+                    $finfo    = new finfo(FILEINFO_MIME_TYPE);
+                    $mimeType = $finfo->file($tmpName);
+                    if (strpos($mimeType, 'image/') !== 0) {
+                        $invalidFile = true;
+                        break;
+                    }
+                }
+            }
+
+            if ($invalidFile) {
+                setEventMessages($langs->trans('ErrorFileNotAnImage'), null, 'errors');
+            } else {
+                $allowOverwrite = GETPOSTINT('overwrite') ? 1 : 0;
+                dol_add_file_process($uploadDir, $allowOverwrite, 1, 'userfile', '', null, '', 1);
             }
         }
     }
@@ -759,25 +804,12 @@ if ($object->id > 0 && (empty($action) || ($action != 'create'))) {
     }
 
     print '<tr class="linked-medias photo question-table"><td class=""><label for="photos">' . $langs->trans("Photo") . '</label></td><td class="linked-medias-list">';
-    $pathPhotos = $conf->digiquali->multidir_output[$conf->entity] . '/control/' . $object->ref . '/photos/';
-    $fileArray  = dol_dir_list($pathPhotos, 'files');
-?>
-    <span class="add-medias" <?php echo ($object->status < Control::STATUS_LOCKED) ? '' : 'style="display:none"' ?>>
-        <input hidden multiple class="fast-upload<?php echo getDolGlobalInt('SATURNE_USE_FAST_UPLOAD_IMPROVEMENT') ? '-improvement' : ''; ?>" id="fast-upload-photo-default" type="file" name="userfile[]" capture="environment" accept="image/*">
-        <input type="hidden" class="fast-upload-options" data-from-subtype="photo" data-from-subdir="photos" />
-        <label for="fast-upload-photo-default">
-            <div class="wpeo-button <?php echo ($onPhone ? 'button-square-40' : 'button-square-50'); ?>">
-                <i class="fas fa-camera"></i><i class="fas fa-plus-circle button-add"></i>
-            </div>
-        </label>
-        <input type="hidden" class="favorite-photo" id="photo" name="photo" value="<?php echo $object->photo ?>" />
-        <div class="wpeo-button <?php echo ($onPhone ? 'button-square-40' : 'button-square-50'); ?> 'open-media-gallery add-media modal-open" value="0">
-            <input type="hidden" class="modal-options" data-modal-to-open="media_gallery" data-from-id="<?php echo $object->id ?>" data-from-type="control" data-from-subtype="photo" data-from-subdir="photos" />
-            <i class="fas fa-folder-open"></i><i class="fas fa-plus-circle button-add"></i>
-        </div>
-    </span>
-    <?php
-    print saturne_show_medias_linked('digiquali', $pathPhotos, 'small', 0, 0, 0, 0, $onPhone ? 40 : 50, $onPhone ? 40 : 50, 0, 0, 0, 'control/' . $object->ref . '/photos/', $object, 'photo', $object->status < Control::STATUS_LOCKED, $permissiontodelete && $object->status < Control::STATUS_LOCKED);
+    print '<input type="hidden" class="favorite-photo" id="photo" name="photo" value="' . dol_escape_htmltag($object->photo) . '"/>';
+    print saturne_render_media_block('digiquali', 'control/' . $object->id . '/photos', '', '', [
+        'show_photo'  => true,
+        'show_audio'  => false,
+        'show_upload' => $object->status < Control::STATUS_LOCKED,
+    ]);
     print '</td></tr>';
 
     $averagePercentageQuestions = 0;
@@ -1228,6 +1260,9 @@ if ($object->id > 0 && (empty($action) || ($action != 'create'))) {
         print dol_get_fiche_end();
     }
 }
+
+// Photo editor modal (required by saturne_render_media_block)
+require_once __DIR__ . '/../../../saturne/core/tpl/medias/photo_editor_modal.tpl.php';
 
 // End of page
 llxFooter();


### PR DESCRIPTION
Closes #2398

## Summary

- Remplace l'ancien bloc fast-upload + saturne_show_medias_linked dans control_card.php (photo principale) par saturne_render_media_block()
- Remplace l'ancien bloc fast-upload + galerie dans digiquali_question_single.tpl.php (photos reponses) par saturne_render_media_block()
- Ajoute le handler action=uploadPhoto, l'include medias.lib.php et photo_editor_modal.tpl.php dans control_card.php
- Chemin des photos du controle base sur $object->id au lieu de $object->ref (stable lors du passage PROV vers ref definitive)
- Met a jour les chemins dans les generateurs PDF et ODT en consequence
- Adapte le CSS de .question__footer pour la nouvelle structure du bloc media

## Test plan

- [ ] Uploader une photo en haut de la card controle - galerie se rafraichit sans doublon
- [ ] Uploader une photo sur une question - editeur s'ouvre, galerie se met a jour
- [ ] Verifier que le bouton camera est masque quand le controle est verrouille
- [ ] Generer un PDF/ODT et verifier que la photo principale apparait bien
- [ ] Creer un controle en PROV, uploader une photo, valider (ref definitive) - photo toujours presente

Generated with Claude Code