### PR TITLE
#2362 [AnswerUI] rework: improve question list density, readability and layout

### DIFF
--- a/core/tpl/digiquali_question_single.tpl.php
+++ b/core/tpl/digiquali_question_single.tpl.php
@@ -50,44 +50,49 @@ if (!isset($user->conf->DIGIQUALI_SHOW_ONLY_QUESTIONS_WITH_NO_ANSWER) || empty($
         <div class="question__container">
             <div class="question__header">
                 <div class="question__header-content">
-                    <div class="question-title"><?php echo $question->getNomUrl(1, '', 0, '', -1, 1); ?></div>
+                    <div class="question-title">
+                        <span class="question-ref"><?php echo $question->getNomUrl(1, '', 0, '', -1, 1); ?></span>
+                        <span class="question-type"><?php echo $langs->trans($question->type); ?></span>
+                    </div>
                     <div class="question-description"><?php echo $question->description; ?></div>
                     <div class="question-points"><?php echo ($showCorrection ? $question->formatSingleQuestionScore($questionWithCorrectAnswer, $objectLine->answer) : '') ?></div>
                 </div>
                 <div class="question__header-answer">
                     <?php print show_answer_from_question($question, $object, $questionAnswer, $questionGroupId, $showCorrection); ?>
+                    <?php if ($question->authorize_answer_photo > 0 || !empty($permissionToAddTask)) : ?>
+                        <div class="question__answer-sep"></div>
+                        <div class="question__answer-actions">
+                            <?php if ($question->authorize_answer_photo > 0) : ?>
+                                <?php echo saturne_render_media_block('digiquali', $object->element . '/' . $object->ref . '/answer_photo/' . $question->ref, 'answer_photo_' . $question->id, '', [
+                                    'show_photo'  => true,
+                                    'show_audio'  => false,
+                                    'show_upload' => $object->status == 0,
+                                ]); ?>
+                            <?php endif; ?>
+                            <?php if (!empty($object->project) && !empty($permissionToAddTask)) : ?>
+                                <div class="wpeo-button button-square-50 add-action modal-open">
+                                    <input type="hidden" class="modal-options" data-modal-to-open="answer_task_add" data-from-id="<?php echo $objectLine->id ?>" data-from-type="<?php echo $objectLine->element ?>"/>
+                                    <i class="fas fa-list"></i><i class="fas fa-plus-circle button-add"></i>
+                                </div>
+                            <?php endif; ?>
+                            <?php if (empty($object->project) && !empty($permissionToAddTask)) :
+                                print '<div class="wpeo-button button-square-50 wpeo-tooltip-event" aria-label="' . $langs->transnoentities('AddProject') . '" id="task-disable" style="background-color: #ececec; border-color: #ececec; color: rgba(0, 0, 0, 0.4) !important;">';
+                                print '    <input type="hidden" class="modal-options" data-modal-to-open="answer_task_add" data-from-id="' . $objectLine->id . '" data-from-type="' . $objectLine->element . '"/>';
+                                print '    <i class="fas fa-list"></i><i class="fas fa-plus-circle button-add"></i>';
+                                print '</div>';
+                            endif; ?>
+                        </div>
+                    <?php endif; ?>
                 </div>
             </div>
-            <div class="question__footer">
-                <?php if ($question->enter_comment > 0) : ?>
+            <?php if ($question->enter_comment > 0) : ?>
+                <div class="question__footer">
                     <label class="question__footer-comment">
                         <i class="far fa-comment-dots question-comment-icon"></i>
                         <textarea name="comment<?php echo $question->id ?>" class="question-textarea question-comment" placeholder="<?php echo $langs->transnoentities('WriteComment'); ?>" <?php echo ($object->status == $object::STATUS_VALIDATED ? 'disabled' : ''); ?>><?php echo $comment; ?></textarea>
                     </label>
-                <?php endif; ?>
-                <?php if ($question->authorize_answer_photo > 0) : ?>
-                    <div class="question__footer-linked-medias">
-                        <?php echo saturne_render_media_block('digiquali', $object->element . '/' . $object->ref . '/answer_photo/' . $question->ref, 'answer_photo_' . $question->id, '', [
-                            'show_photo'  => true,
-                            'show_audio'  => false,
-                            'show_upload' => $object->status == 0,
-                        ]); ?>
-                    </div>
-                <?php endif; ?>
-                <?php if (!empty($object->project) && !empty($permissionToAddTask)) : ?>
-                    <div class="wpeo-button button-square-50 add-action modal-open">
-                        <input type="hidden" class="modal-options" data-modal-to-open="answer_task_add" data-from-id="<?php echo $objectLine->id ?>" data-from-type="<?php echo $objectLine->element ?>"/>
-                        <i class="fas fa-list"></i><i class="fas fa-plus-circle button-add"></i>
-                    </div>
-                <?php endif;
-                if (empty($object->project) && !empty($permissionToAddTask)) {
-                    print '<div class="wpeo-button button-square-50 wpeo-tooltip-event" aria-label="' . $langs->transnoentities('AddProject') . '" id="task-disable" style="background-color: #ececec; border-color: #ececec; color: rgba(0, 0, 0, 0.4) !important;">';
-                    print '    <input type="hidden" class="modal-options" data-modal-to-open="answer_task_add" data-from-id="' . $objectLine->id . '" data-from-type="' . $objectLine->element . '"/>';
-                    print '    <i class="fas fa-list"></i><i class="fas fa-plus-circle button-add"></i>';
-                    print '</div>';
-                }
-                ?>
-            </div>
+                </div>
+            <?php endif; ?>
             <?php
             if (!empty($permissionToReadTask)) :
                 require __DIR__ . '/answers/answers_task_view.tpl.php';

--- a/css/scss/page/answer/_answer.scss
+++ b/css/scss/page/answer/_answer.scss
@@ -22,7 +22,7 @@
     //padding: 1.4em;
     border-radius: 12px;
     box-shadow: 0 4px 4px rgba(27,100,168,0.15);
-    margin-bottom: 1em;
+    margin-bottom: 0.5em;
     position: relative;
     //overflow: hidden;
     display: flex;
@@ -99,7 +99,7 @@
       }
     }
     .question__container {
-      padding: 1em;
+      padding: 0.3em 0.6em 0.25em;
       width: 100%;
     }
 
@@ -108,18 +108,38 @@
       flex-direction: row;
       flex-wrap: nowrap;
       gap: 0.5em;
-      margin-bottom: 1.5em;
+      margin-bottom: 0.3em;
+
+      @media (max-width: $media__small) {
+        flex-direction: column;
+      }
 
       .question__header-content {
         width: 100%;
       }
       .question-title {
-        font-size: 16px;
-        font-weight: 600;
-        color: $color__public-primary;
+        display: flex;
+        align-items: center;
+        gap: 0.4em;
+        flex-wrap: wrap;
+
+        .question-ref {
+          font-size: 16px;
+          font-weight: 600;
+          color: $color__public-primary;
+        }
+        .question-type {
+          font-size: 13px;
+          font-weight: 500;
+          color: #666;
+          background: #edf0f5;
+          border-radius: 4px;
+          padding: 1px 6px;
+          white-space: nowrap;
+        }
       }
       .question-description {
-        font-size: 14px;
+        font-size: 16px;
         color: #777777;
       }
       .question__header-medias {
@@ -143,6 +163,49 @@
     }
 
     .question__header-answer {
+      display: flex;
+      align-items: center;
+      gap: 0.5em;
+
+      .question__answer-sep {
+        width: 1px;
+        align-self: stretch;
+        background: rgba($color__public-secondary, 0.5);
+        flex-shrink: 0;
+      }
+
+      .question__answer-actions {
+        display: flex;
+        align-items: center;
+        gap: 0.4em;
+        flex-shrink: 0;
+
+        .linked-medias {
+          gap: 0;
+          margin-bottom: 0;
+        }
+        .saturne-media-upload-block {
+          gap: 4px;
+        }
+        .button-linked-medias {
+          overflow: visible;
+
+          .button-badge {
+            position: absolute;
+            top: -11px;
+            left: -11px;
+            width: 22px;
+            height: 22px;
+            border-radius: 50%;
+            background: $color__red;
+            text-align: center;
+            line-height: 22px;
+            font-weight: 600;
+            font-size: 11px;
+          }
+        }
+      }
+
       .percentage-cell {
         width: 100%;
         display: flex;
@@ -231,14 +294,18 @@
         flex-direction: row;
         flex-wrap: wrap;
         justify-content: center;
-        gap: 1em;
+        gap: 0.6em;
         width: auto;
+
+        @media (max-width: $media__small) {
+          justify-content: flex-start;
+        }
 
         .answer {
           border: 4px solid #fff;
           border-radius: 8px;
-          padding: 0.4em 0.8em;
-          font-size: 18px;
+          padding: 0.3em 0.6em;
+          font-size: 16px;
           transition: all 0.2s ease-out;
           display: flex;
           align-items: center;
@@ -283,11 +350,7 @@
     }
 
     .question__footer {
-      display: flex;
-      flex-direction: row;
-      flex-wrap: nowrap;
-      gap: 0.5em;
-      align-items: flex-start;
+      margin-top: 0.4em;
 
       .question__footer-comment {
         width: 100%;
@@ -331,38 +394,6 @@
         }
       }
 
-      .question__footer-linked-medias {
-        flex-shrink: 0;
-
-        .linked-medias {
-          gap: 0;
-          margin-bottom: 0;
-        }
-
-        .saturne-media-upload-block {
-          gap: 4px;
-        }
-      }
-      .add-action {
-        min-width: 50px;
-      }
-      .button-linked-medias {
-        overflow: visible;
-
-        .button-badge {
-          position: absolute;
-          top: -11px;
-          left: -11px;
-          width: 22px;
-          height: 22px;
-          border-radius: 50%;
-          background: $color__red;
-          text-align: center;
-          line-height: 22px;
-          font-weight: 600;
-          font-size: 11px;
-        }
-      }
     }
 
     .question__list-medias {
@@ -437,6 +468,37 @@
   }
 
   .digiquali-question-group {
+    margin: 0 0 0.6em;
+    padding: 0.5em 0.6em;
+
+    > h3 {
+      font-size: 18px;
+      margin: 0 0 0.3em;
+      padding: 0.3em 0.5em;
+      background: rgba($color__public-secondary, 0.15);
+      border-radius: 8px;
+    }
+
+    > .group-description {
+      font-size: 15px;
+      color: #666;
+      margin: 0 0 0.3em;
+      padding: 0 0.5em;
+    }
+
+    > p {
+      margin: 0 0 0.2em;
+      padding: 0 0.5em;
+      font-size: 15px;
+    }
+
+    .group-questions {
+      display: flex;
+      flex-direction: column;
+      gap: 0.4em;
+      padding-top: 0;
+    }
+
     &.correct {
       border-color: $color__correct;
     }


### PR DESCRIPTION
## Résumé

- Affichage de la ref question en plus petit avec le type en badge inline sur la même ligne
- Déplacement des boutons photo/tâche à droite des réponses, séparés par un pipe vertical
- Compression des paddings des cartes question et des marges des groupes
- Restitution de la description de la question sous le titre
- Ajustement des tailles de police pour une meilleure lisibilité
- Espacement entre les questions via gap sur .group-questions

## Fichiers modifiés

- core/tpl/digiquali_question_single.tpl.php
- css/scss/page/answer/_answer.scss

## Plan de test

- [ ] Vérifier l'affichage des questions avec groupes (backend desktop)
- [ ] Vérifier l'affichage sur mobile (< 600px)
- [ ] Vérifier que les boutons photo et tâche s'affichent bien à droite des réponses
- [ ] Vérifier que le séparateur pipe est visible
- [ ] Vérifier que la description s'affiche sous la ref/type
- [ ] Vérifier les groupes imbriqués

Closes #2362

Generated with Claude Code
