### PR TITLE
#2408 [PDF] fix: reduce question card inner padding to limit whitespace

### DIFF
--- a/core/modules/digiquali/digiqualidocuments/controldocument/pdf_controldocument.modules.php
+++ b/core/modules/digiquali/digiqualidocuments/controldocument/pdf_controldocument.modules.php
@@ -765,7 +765,7 @@ class pdf_controldocument extends SaturneDocumentModel
             $rightTextH = $pdf->getNumLines($answerText, $textColW - 6) * 3.5;
         }
 
-        $innerPad = 2.5;
+        $innerPad = 1.5;
         $leftH    = $innerPad + 5 + $titleH
             + ($descH > 0 ? $descH + 1 : 0)
             + ($obsH > 0 ? $obsH + 2 : 0)


### PR DESCRIPTION
#2408

## Changements

- Reduction de innerPad de 2.5 a 1.5 mm dans drawQuestionCard pour limiter l'espace blanc en haut et en bas de chaque carte de question

## Fichiers modifies

- core/modules/digiquali/digiqualidocuments/controldocument/pdf_controldocument.modules.php