### PR TITLE
#2407 [PublicAnswer] feat: display controlled object info in public answer header

### DIFF
--- a/core/tpl/frontend/control_answer_public_header.tpl.php
+++ b/core/tpl/frontend/control_answer_public_header.tpl.php
@@ -34,7 +34,13 @@ $linkedObjectInfoArray = get_linked_object_infos($linkedObject, $linkableElement
 
 <div class="public-answer-header">
     <div class="public-answer-header__object">
-        <div class="public-answer-header__thumbnail"><?php echo $linkedObjectInfoArray['images']; ?></div>
+        <?php if (!empty($linkedObjectInfoArray['images']) && strpos($linkedObjectInfoArray['images'], 'nophoto') === false) : ?>
+            <div class="public-answer-header__thumbnail"><?php echo $linkedObjectInfoArray['images']; ?></div>
+        <?php else : ?>
+            <div class="public-answer-header__thumbnail public-answer-header__thumbnail--placeholder">
+                <i class="fas fa-box"></i>
+            </div>
+        <?php endif; ?>
         <div class="public-answer-header__info">
             <div class="public-answer-header__type"><?php echo $linkedObjectInfoArray['linkedObject']['title']; ?></div>
             <div class="public-answer-header__name"><?php echo $linkedObjectInfoArray['linkedObject']['name_field']; ?></div>

--- a/core/tpl/frontend/control_answer_public_header.tpl.php
+++ b/core/tpl/frontend/control_answer_public_header.tpl.php
@@ -44,6 +44,12 @@ $linkedObjectInfoArray = get_linked_object_infos($linkedObject, $linkableElement
         <div class="public-answer-header__info">
             <div class="public-answer-header__type"><?php echo $linkedObjectInfoArray['linkedObject']['title']; ?></div>
             <div class="public-answer-header__name"><?php echo $linkedObjectInfoArray['linkedObject']['name_field']; ?></div>
+            <?php if (!empty($linkedObjectInfoArray['linkedObject']['label'])) : ?>
+                <div class="public-answer-header__label"><?php echo $linkedObjectInfoArray['linkedObject']['label']; ?></div>
+            <?php endif; ?>
+            <?php if (!empty($linkedObjectInfoArray['linkedObject']['description'])) : ?>
+                <div class="public-answer-header__description"><?php echo $linkedObjectInfoArray['linkedObject']['description']; ?></div>
+            <?php endif; ?>
             <?php if (!empty($linkedObjectInfoArray['parentLinkedObject']['title'])) : ?>
                 <div class="public-answer-header__type"><?php echo $linkedObjectInfoArray['parentLinkedObject']['title']; ?></div>
                 <div class="public-answer-header__name"><?php echo $linkedObjectInfoArray['parentLinkedObject']['name_field']; ?></div>

--- a/core/tpl/frontend/control_answer_public_header.tpl.php
+++ b/core/tpl/frontend/control_answer_public_header.tpl.php
@@ -1,0 +1,53 @@
+<?php
+/* Copyright (C) 2025 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    core/tpl/frontend/control_answer_public_header.tpl.php
+ * \ingroup digiquali
+ * \brief   Template for linked object header on public answer interface
+ */
+
+/**
+ * Variables requises :
+ * $object           - Control (avec linkedObjects chargés)
+ * $linkedObject     - CommonObject lié (Product, ProductLot, Project…)
+ * $linkableElements - tableau retourné par saturne_get_objects_metadata()
+ * $sheet            - Sheet (déjà fetchée dans public_answer.php)
+ * $langs            - Traductions
+ */
+
+$linkedObjectInfoArray = get_linked_object_infos($linkedObject, $linkableElements); ?>
+
+<div class="public-answer-header">
+    <div class="public-answer-header__object">
+        <div class="public-answer-header__thumbnail"><?php echo $linkedObjectInfoArray['images']; ?></div>
+        <div class="public-answer-header__info">
+            <div class="public-answer-header__type"><?php echo $linkedObjectInfoArray['linkedObject']['title']; ?></div>
+            <div class="public-answer-header__name"><?php echo $linkedObjectInfoArray['linkedObject']['name_field']; ?></div>
+            <?php if (!empty($linkedObjectInfoArray['parentLinkedObject']['title'])) : ?>
+                <div class="public-answer-header__type"><?php echo $linkedObjectInfoArray['parentLinkedObject']['title']; ?></div>
+                <div class="public-answer-header__name"><?php echo $linkedObjectInfoArray['parentLinkedObject']['name_field']; ?></div>
+            <?php endif; ?>
+        </div>
+    </div>
+    <div class="public-answer-header__control">
+        <div class="public-answer-header__type"><?php echo $langs->transnoentities('Control'); ?></div>
+        <div class="public-answer-header__name"><?php echo $object->ref; ?></div>
+        <div class="public-answer-header__type"><?php echo $langs->transnoentities('Sheet'); ?></div>
+        <div class="public-answer-header__name"><?php echo $sheet->label ?: $sheet->ref; ?></div>
+    </div>
+</div>

--- a/core/tpl/frontend/control_answer_public_header.tpl.php
+++ b/core/tpl/frontend/control_answer_public_header.tpl.php
@@ -38,7 +38,7 @@ $linkedObjectInfoArray = get_linked_object_infos($linkedObject, $linkableElement
             <div class="public-answer-header__thumbnail"><?php echo $linkedObjectInfoArray['images']; ?></div>
         <?php else : ?>
             <div class="public-answer-header__thumbnail public-answer-header__thumbnail--placeholder">
-                <i class="fas fa-box"></i>
+                <?php echo img_picto('', $linkableElements[$linkedObject->element]['picto'] ?? 'generic'); ?>
             </div>
         <?php endif; ?>
         <div class="public-answer-header__info">

--- a/css/scss/page/_public-answer.scss
+++ b/css/scss/page/_public-answer.scss
@@ -31,6 +31,18 @@
       object-fit: cover;
       border-radius: 8px;
     }
+
+    &--placeholder {
+      width: 80px;
+      height: 80px;
+      background: rgba($color__public-secondary, 0.12);
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: $color__public-secondary;
+      font-size: 2em;
+    }
   }
 
   &__info {

--- a/css/scss/page/_public-answer.scss
+++ b/css/scss/page/_public-answer.scss
@@ -37,6 +37,7 @@
     display: flex;
     flex-direction: column;
     gap: 0.1em;
+    min-width: 0;
   }
 
   &__control {
@@ -67,5 +68,11 @@
     font-size: 16px;
     font-weight: 600;
     color: $color__public-primary;
+    overflow-wrap: break-word;
+    word-break: break-word;
+
+    a {
+      color: inherit;
+    }
   }
 }

--- a/css/scss/page/_public-answer.scss
+++ b/css/scss/page/_public-answer.scss
@@ -87,4 +87,20 @@
       color: inherit;
     }
   }
+
+  &__label {
+    font-size: 14px;
+    font-weight: 500;
+    color: $color__public-primary;
+    overflow-wrap: break-word;
+    word-break: break-word;
+  }
+
+  &__description {
+    font-size: 13px;
+    color: #888;
+    overflow-wrap: break-word;
+    word-break: break-word;
+    margin-top: 0.1em;
+  }
 }

--- a/css/scss/page/_public-answer.scss
+++ b/css/scss/page/_public-answer.scss
@@ -1,0 +1,71 @@
+@import "answer/_answer.scss";
+
+.public-answer-header {
+  display: flex;
+  align-items: center;
+  gap: 1em;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 4px 4px rgba(27, 100, 168, 0.15);
+  padding: 1em;
+  margin-bottom: 1em;
+
+  @media (max-width: $media__small) {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  &__object {
+    display: flex;
+    align-items: center;
+    gap: 0.8em;
+    flex: 1;
+  }
+
+  &__thumbnail {
+    flex-shrink: 0;
+
+    img {
+      width: 80px;
+      height: 80px;
+      object-fit: cover;
+      border-radius: 8px;
+    }
+  }
+
+  &__info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1em;
+  }
+
+  &__control {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1em;
+    border-left: 2px solid rgba($color__public-secondary, 0.3);
+    padding-left: 1em;
+
+    @media (max-width: $media__small) {
+      border-left: none;
+      border-top: 2px solid rgba($color__public-secondary, 0.3);
+      padding-left: 0;
+      padding-top: 0.8em;
+      width: 100%;
+    }
+  }
+
+  &__type {
+    font-size: 12px;
+    font-weight: 500;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  &__name {
+    font-size: 16px;
+    font-weight: 600;
+    color: $color__public-primary;
+  }
+}

--- a/lib/digiquali_control.lib.php
+++ b/lib/digiquali_control.lib.php
@@ -178,7 +178,7 @@ function get_linked_object_infos(CommonObject $linkedObject, array $linkableElem
     }
 
     $out['images'] = $out['linkedObject']['images'];
-    if (strpos($out['parentLinkedObject']['images'], 'nophoto') === false) {
+    if (!empty($out['parentLinkedObject']['images']) && strpos($out['parentLinkedObject']['images'], 'nophoto') === false) {
         $out['images'] = $out['parentLinkedObject']['images'];
     }
 

--- a/lib/digiquali_control.lib.php
+++ b/lib/digiquali_control.lib.php
@@ -112,8 +112,28 @@ function get_linked_object_infos(CommonObject $linkedObject, array $linkableElem
 
     $out['linkedObject']['links'] = [];
     $out['linkedObject']['files'] = $filteredEcmFilesLine;
-    $out['linkedObject']['title']        = $langs->transnoentities($linkableElement['langs']);
-    $out['linkedObject']['name_field']   = $linkedObject->getNomUrl(1, !$permissionToRead ? 'nolink' : '');
+    $out['linkedObject']['title']      = $langs->transnoentities($linkableElement['langs']);
+    $out['linkedObject']['name_field'] = $linkedObject->getNomUrl(1, !$permissionToRead ? 'nolink' : '');
+
+    // Per-element label and description field mapping
+    $elementFieldsMap = [
+        'product'    => ['label' => 'label',  'description' => 'description'],
+        'productlot' => ['label' => '',       'description' => 'note_public'],
+        'user'       => ['label' => '',       'description' => 'job'],
+        'thirdparty' => ['label' => '',       'description' => 'note_public'],
+        'contact'    => ['label' => '',       'description' => 'poste'],
+        'project'    => ['label' => 'title',  'description' => 'description'],
+        'task'       => ['label' => 'label',  'description' => 'description'],
+    ];
+
+    $fields = $elementFieldsMap[$linkedObject->element] ?? ['label' => '', 'description' => ''];
+
+    $out['linkedObject']['label']       = ($fields['label'] && !empty($linkedObject->{$fields['label']}))
+        ? dol_escape_htmltag($linkedObject->{$fields['label']})
+        : '';
+    $out['linkedObject']['description'] = ($fields['description'] && !empty($linkedObject->{$fields['description']}))
+        ? dol_escape_htmltag($linkedObject->{$fields['description']})
+        : '';
 
     $link->fetchAll($out['linkedObject']['links'], $linkedObject->element, $linkedObject->id);
 

--- a/lib/digiquali_control.lib.php
+++ b/lib/digiquali_control.lib.php
@@ -113,7 +113,7 @@ function get_linked_object_infos(CommonObject $linkedObject, array $linkableElem
     $out['linkedObject']['links'] = [];
     $out['linkedObject']['files'] = $filteredEcmFilesLine;
     $out['linkedObject']['title']        = $langs->transnoentities($linkableElement['langs']);
-    $out['linkedObject']['name_field']   = $linkedObject->getNomUrl(1, !$permissionToRead ? 'nolink' : '', 1);
+    $out['linkedObject']['name_field']   = $linkedObject->getNomUrl(1, !$permissionToRead ? 'nolink' : '');
 
     $link->fetchAll($out['linkedObject']['links'], $linkedObject->element, $linkedObject->id);
 

--- a/public/public_answer.php
+++ b/public/public_answer.php
@@ -171,11 +171,10 @@ print '<input type="hidden" name="action" value="save">';
 $sheet->fetch($object->fk_sheet);
 $questionsAndGroups = $sheet->fetchQuestionsAndGroups();
 
+print '<div class="question-answer-container question-answer-container-pwa public-card__container" data-public-interface="true" style="max-width: 1000px; margin-bottom: 4em;">';
 if (!empty($linkedObject)) {
     require __DIR__ . '/../core/tpl/frontend/control_answer_public_header.tpl.php';
 }
-
-print '<div class="question-answer-container question-answer-container-pwa public-card__container" data-public-interface="true" style="max-width: 1000px; margin-bottom: 4em;">';
 $substitutionArray = getCommonSubstitutionArray($langs, 0, null, $object);
 complete_substitutions_array($substitutionArray, $langs, $object);
 $answerPublicInterfaceTitle = make_substitutions($langs->transnoentities($conf->global->DIGIQUALI_ANSWER_PUBLIC_INTERFACE_TITLE), $substitutionArray);

--- a/public/public_answer.php
+++ b/public/public_answer.php
@@ -168,6 +168,9 @@ print '<input type="hidden" name="token" value="' . newToken() . '">';
 print '<input type="hidden" name="public_interface" value="true">';
 print '<input type="hidden" name="action" value="save">';
 
+$sheet->fetch($object->fk_sheet);
+$questionsAndGroups = $sheet->fetchQuestionsAndGroups();
+
 if (!empty($linkedObject)) {
     require __DIR__ . '/../core/tpl/frontend/control_answer_public_header.tpl.php';
 }
@@ -180,9 +183,6 @@ if (getDolGlobalInt('DIGIQUALI_ANSWER_PUBLIC_INTERFACE_SHOW_TITLE')) {
     print '<h2 class="page-title center">' . (dol_strlen($answerPublicInterfaceTitle) > 0 ? $answerPublicInterfaceTitle : $langs->transnoentities('AnswerPublicInterface')) . '</h2>';
 }
 $publicInterface = true;
-
-$sheet->fetch($object->fk_sheet);
-$questionsAndGroups = $sheet->fetchQuestionsAndGroups();
 
 $isFrontend = true;
 $object->displayAnswers($objectLine, $questionsAndGroups, $isFrontend);

--- a/public/public_answer.php
+++ b/public/public_answer.php
@@ -171,15 +171,16 @@ print '<input type="hidden" name="action" value="save">';
 $sheet->fetch($object->fk_sheet);
 $questionsAndGroups = $sheet->fetchQuestionsAndGroups();
 
-print '<div class="question-answer-container question-answer-container-pwa public-card__container" data-public-interface="true" style="max-width: 1000px; margin-bottom: 4em;">';
-if (!empty($linkedObject)) {
-    require __DIR__ . '/../core/tpl/frontend/control_answer_public_header.tpl.php';
-}
 $substitutionArray = getCommonSubstitutionArray($langs, 0, null, $object);
 complete_substitutions_array($substitutionArray, $langs, $object);
 $answerPublicInterfaceTitle = make_substitutions($langs->transnoentities($conf->global->DIGIQUALI_ANSWER_PUBLIC_INTERFACE_TITLE), $substitutionArray);
 if (getDolGlobalInt('DIGIQUALI_ANSWER_PUBLIC_INTERFACE_SHOW_TITLE')) {
     print '<h2 class="page-title center">' . (dol_strlen($answerPublicInterfaceTitle) > 0 ? $answerPublicInterfaceTitle : $langs->transnoentities('AnswerPublicInterface')) . '</h2>';
+}
+
+print '<div class="question-answer-container question-answer-container-pwa public-card__container" data-public-interface="true" style="max-width: 1000px; margin-bottom: 4em;">';
+if (!empty($linkedObject)) {
+    require __DIR__ . '/../core/tpl/frontend/control_answer_public_header.tpl.php';
 }
 $publicInterface = true;
 

--- a/public/public_answer.php
+++ b/public/public_answer.php
@@ -69,6 +69,8 @@ require_once __DIR__ . '/../class/questiongroup.class.php';
 require_once __DIR__ . '/../class/answer.class.php';
 require_once __DIR__ . '/../lib/digiquali_sheet.lib.php';
 require_once __DIR__ . '/../lib/digiquali_answer.lib.php';
+require_once DOL_DOCUMENT_ROOT . '/product/stock/class/productlot.class.php';
+require_once __DIR__ . '/../lib/digiquali_control.lib.php';
 
 // Global variables definitions
 global $conf, $db, $hookmanager, $moduleNameLowerCase, $langs, $user;
@@ -115,6 +117,14 @@ $conf->setEntityValues($db, $entity);
 
 // Load object
 $object->fetch(0, '', ' AND track_id = ' . "'" . $trackID . "'");
+
+$linkableElements = saturne_get_objects_metadata();
+$object->fetchObjectLinked('', '', '', 'digiquali_control');
+$linkedObjectType = key($object->linkedObjects);
+$linkedObject     = (is_array($object->linkedObjects[$linkedObjectType] ?? null) && !empty($object->linkedObjects[$linkedObjectType]))
+    ? current($object->linkedObjects[$linkedObjectType])
+    : null;
+
 if (getDolGlobalInt('DIGIQUALI_ANSWER_PUBLIC_INTERFACE_USE_SIGNATORY')) {
     $signatory->fetch(0, '', ' AND status >= ' . SaturneSignature::STATUS_REGISTERED . ' AND object_type= ' . "'" . $object->element . "'" . ' AND fk_object = ' . "'" . $object->id . "'");
 }
@@ -157,6 +167,10 @@ print '<form method="POST" action="' . $_SERVER['PHP_SELF'] . '?action=save&id='
 print '<input type="hidden" name="token" value="' . newToken() . '">';
 print '<input type="hidden" name="public_interface" value="true">';
 print '<input type="hidden" name="action" value="save">';
+
+if (!empty($linkedObject)) {
+    require __DIR__ . '/../core/tpl/frontend/control_answer_public_header.tpl.php';
+}
 
 print '<div class="question-answer-container question-answer-container-pwa public-card__container" data-public-interface="true" style="max-width: 1000px; margin-bottom: 4em;">';
 $substitutionArray = getCommonSubstitutionArray($langs, 0, null, $object);


### PR DESCRIPTION
## Changements

- Ajout d'un en-tete dans l'interface publique de reponse affichant les informations de l'objet controle
- Affichage de la photo de l'objet (ou placeholder avec pictogramme specifique au type)
- Affichage du type, nom complet, label et description de l'objet
- Support de tous les types d'elements controlables : product, productlot, user, thirdparty, contact, project, task
- Affichage du ref du controle et du label/ref de la fiche
- Correction du bug de troncature du nom (getNomUrl sans maxlength)
- Correction du bug d'affichage photo (guard !empty sur parentLinkedObject images)
- Style BEM responsive via SCSS (_public-answer.scss)

## Fichiers modifies

- core/tpl/frontend/control_answer_public_header.tpl.php (nouveau)
- public/public_answer.php
- lib/digiquali_control.lib.php
- css/scss/page/_public-answer.scss

## Issue
#2407