### PR TITLE
[Sheet][Control] Désarchivage des éléments

### DIFF
--- a/view/control/control_card.php
+++ b/view/control/control_card.php
@@ -979,6 +979,12 @@ if ($object->id > 0 && (empty($action) || ($action != 'create'))) {
                 print '<span class="butActionRefused classfortooltip" title="' . dol_escape_htmltag($langs->trans('ObjectMustBeLockedToArchive', ucfirst($langs->transnoentities('The' . ucfirst($object->element))))) . '">' . $displayButton . '</span>';
             }
 
+            // Unarchive
+            $displayButton = $onPhone ? '<i class="fas fa-box-open fa-2x"></i>' : '<i class="fas fa-box-open"></i>' . ' ' . $langs->trans('Unarchive');
+            if ($object->status == Control::STATUS_ARCHIVED) {
+                print '<a class="butAction" href="' . $_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=confirm_unarchive&token=' . newToken() . '">' . $displayButton . '</a>';
+            }
+
             // Clone
             $displayButton = $onPhone ? '<i class="fas fa-clone fa-2x"></i>' : '<i class="fas fa-clone"></i>' . ' ' . $langs->trans('ToClone');
             print '<span class="butAction" id="actionButtonClone">' . $displayButton . '</span>';

--- a/view/control/control_list.php
+++ b/view/control/control_list.php
@@ -146,7 +146,7 @@ $excludeFields = array_merge($excludeFields, ['days_remaining_before_next_contro
 // Initialize array of search criterias
 $searchAll = trim(GETPOST('search_all'));
 $search    = [];
-$search['status'] = [0, 1,2];
+$search['status'] = saturne_get_status_search_filter([Control::STATUS_DRAFT, Control::STATUS_VALIDATED, Control::STATUS_LOCKED]);
 foreach ($object->fields as $key => $val) {
     if (GETPOST('search_' . $key, 'alpha') !== '') {
         $search[$key] = GETPOST('search_' . $key, 'alpha');

--- a/view/sheet/sheet_card.php
+++ b/view/sheet/sheet_card.php
@@ -401,6 +401,25 @@ if (empty($reshook)) {
         }
     }
 
+    // Action to set status back to STATUS_VALIDATED from STATUS_ARCHIVED.
+    if ($action == 'confirm_unarchive' && $permissiontoadd) {
+        $object->fetch($id);
+        if (!$error) {
+            $result = $object->setUnarchived($user);
+            if ($result > 0) {
+                // Set Unarchived OK.
+                $urltogo = str_replace('__ID__', $result, $backtopage);
+                $urltogo = preg_replace('/--IDFORBACKTOPAGE--/', $id, $urltogo);
+                header('Location: ' . $urltogo);
+                exit;
+            } elseif (!empty($object->errors)) { // Set Unarchived KO.
+                setEventMessages('', $object->errors, 'errors');
+            } else {
+                setEventMessages($object->error, [], 'errors');
+            }
+        }
+    }
+
     if ($action == 'set_mandatory' && $permissiontoadd) {
         $questionId = GETPOST('questionId', 'int');
 		$questionRef = GETPOST('questionRef', 'alpha');
@@ -786,6 +805,11 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
                 print '<a class="butAction" href="' . $_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=confirm_archive&token=' . newToken() . '"><i class="fas fa-archive"></i> ' . $langs->trans('Archive') . '</a>';
             } else {
                 print '<span class="butActionRefused classfortooltip" title="' . dol_escape_htmltag($langs->trans('ObjectMustBeLockedToArchive', ucfirst($langs->transnoentities('The' . ucfirst($object->element))))) . '"><i class="fas fa-archive"></i> ' . $langs->trans('Archive') . '</span>';
+            }
+
+            // Unarchive
+            if ($object->status == $object::STATUS_ARCHIVED) {
+                print '<a class="butAction" href="' . $_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=confirm_unarchive&token=' . newToken() . '"><i class="fas fa-box-open"></i> ' . $langs->trans('Unarchive') . '</a>';
             }
 
 			// Delete (need delete permission, or if draft, just need create/modify permission)

--- a/view/sheet/sheet_list.php
+++ b/view/sheet/sheet_list.php
@@ -100,7 +100,7 @@ $excludeFields                  = ['nb_questions'];
 // Initialize array of search criterias
 $searchAll        = trim(GETPOST('search_all'));
 $search           = [];
-$search['status'] = [1,2];
+$search['status'] = saturne_get_status_search_filter([Sheet::STATUS_VALIDATED, Sheet::STATUS_LOCKED]);
 foreach ($object->fields as $key => $val) {
     if (GETPOST('search_' . $key, 'alpha') !== '') {
         $search[$key] = GETPOST('search_' . $key, 'alpha');


### PR DESCRIPTION
## Objectif
Permettre de **désarchiver** les Modèles (Sheet) et Contrôles (Control) depuis la liste (action de masse) et la fiche.

Dépend des nouveautés saturne (Evarisk/Saturne#1365, mergé sur develop) : `setUnarchived()`, action de masse `unarchive`, handler `confirm_unarchive`, helper `saturne_get_status_search_filter()`.

## Changements
- `sheet_list.php` / `control_list.php` : le défaut statut passe par `saturne_get_status_search_filter()` → le multiselect statut est enfin honoré, les archivés deviennent atteignables.
- `sheet_card.php` : bouton « Désarchiver » (si archivé) + handler `confirm_unarchive` inline.
- `control_card.php` : bouton « Désarchiver » (si archivé) ; handler fourni par le template saturne.

Statut cible : Validé (1).

Closes #2416