### PR TITLE
[Sheet][Control] Objet verrouillé/archivé en lecture seule (garde serveur)

### DIFF
--- a/core/tpl/digiquali_answers_save_action.tpl.php
+++ b/core/tpl/digiquali_answers_save_action.tpl.php
@@ -52,9 +52,7 @@ if ($action == 'save') {
 
     $sheet->fetch($object->fk_sheet);
     $questions = $sheet->fetchAllQuestions();
-    
-    file_put_contents('c:/wamp64/www/dolibarr22/dolibarr/documents/debug.log', "Total questions fetched: " . (is_array($questions) || is_object($questions) ? count($questions) : 0) . "\n", FILE_APPEND);
-    
+
     if (!empty($questions)) {
         $controlLineObj = new ControlLine($db);
         foreach ($questions as $question) {

--- a/view/control/control_card.php
+++ b/view/control/control_card.php
@@ -167,6 +167,13 @@ if ($resHook < 0) {
 if (empty($resHook)) {
     $error = 0;
 
+    // Block content-modifying actions on read-only (locked/archived) objects
+    $modifyingActions = ['set_categories', 'confirm_setVerdict', 'confirm_set_reopen', 'uploadPhoto', 'save', 'update'];
+    if ((in_array($action, $modifyingActions) || preg_match('/^set[a-z]/', $action)) && isset($object->status) && !$object->isModifiable()) {
+        setEventMessages($langs->trans('ObjectIsReadOnly', ucfirst($langs->transnoentities('The' . ucfirst($object->element)))), [], 'warnings');
+        $action = '';
+    }
+
     $backurlforlist = dol_buildpath('/digiquali/view/control/control_list.php?source=' . $source, 1);
 
     if (empty($backtopage) || ($cancel && empty($id))) {
@@ -278,7 +285,7 @@ if (empty($resHook)) {
     }
 
     // Action to set status STATUS_REOPENED
-    if ($action == 'confirm_set_reopen') {
+    if ($action == 'confirm_set_reopen' && $permissiontoadd) {
         $object->fetch($id);
         if (!$error) {
             $result = $object->setDraft($user, false);

--- a/view/sheet/sheet_card.php
+++ b/view/sheet/sheet_card.php
@@ -115,7 +115,14 @@ if (empty($reshook)) {
 		}
 	}
 
-    if ($action == 'addQuestionGroup') {
+    // Block content-modifying actions on read-only (locked/archived) objects
+    $modifyingActions = ['addQuestionGroup', 'addQuestion', 'unlinkQuestion', 'unlinkQuestionGroup', 'update', 'moveLine', 'set_mandatory'];
+    if ((in_array($action, $modifyingActions) || preg_match('/^set[a-z]/', $action)) && isset($object->status) && !$object->isModifiable()) {
+        setEventMessages($langs->trans('ObjectIsReadOnly', ucfirst($langs->transnoentities('The' . ucfirst($object->element)))), [], 'warnings');
+        $action = '';
+    }
+
+    if ($action == 'addQuestionGroup' && $permissiontoadd) {
         $questionGroupId = GETPOST('questionGroupId');
         $targetQuestionGroupId = GETPOST('targetGroupId');
         if ($questionGroupId > 0) {


### PR DESCRIPTION
Impose côté serveur qu'un Modèle/Contrôle `status >= LOCKED` (verrouillé/archivé) n'accepte aucune modification de contenu (la protection était uniquement visuelle).

S'appuie sur Evarisk/Saturne#1369 (`isModifiable()` + `ObjectIsReadOnly`).

## Changements
- Bloc de garde (no-op + message) en tête des actions de `sheet_card.php` et `control_card.php`, placé avant l'include `actions_addupdatedelete.inc.php` : neutralise les actions modifiantes (liste explicite + éditions inline `^set`) quand `!$object->isModifiable()`.
- Permissions manquantes ajoutées : `addQuestionGroup` (Sheet), `confirm_set_reopen` (Control — fermait le contournement archivé→brouillon).
- Suppression d'une ligne de debug oubliée (`debug.log` chemin `dolibarr22`) dans `digiquali_answers_save_action.tpl.php`.

Hors-scope : `public/public_answer.php`.

Closes #2418