### PR TITLE
#2423 [Question] fix: éviter le TypeError sur Question::$points avec un champ Points vide

### DIFF
--- a/view/question/question_card.php
+++ b/view/question/question_card.php
@@ -161,6 +161,9 @@ if (empty($reshook)) {
 				$value = 60 * 60 * GETPOST($key.'hour', 'int') + 60 * GETPOST($key.'min', 'int');
 			} elseif (preg_match('/^(integer|price|real|double)/', $object->fields[$key]['type'])) {
 				$value = price2num(GETPOST($key, 'alphanohtml')); // To fix decimal separator according to lang setup
+				if ($value === '') {
+					$value = null; // Empty numeric input: store NULL (avoids TypeError on typed nullable properties such as Question::$points)
+				}
 			} elseif ($object->fields[$key]['type'] == 'boolean') {
 				$value = ((GETPOST($key) == '1' || GETPOST($key) == 'on') ? 1 : 0);
 			} elseif ($object->fields[$key]['type'] == 'reference') {
@@ -538,6 +541,9 @@ if (empty($reshook)) {
 				}
 			} elseif (preg_match('/^(integer|price|real|double)/', $object->fields[$key]['type'])) {
 				$value = price2num(GETPOST($key, 'alphanohtml')); // To fix decimal separator according to lang setup
+				if ($value === '') {
+					$value = null; // Empty numeric input: store NULL (avoids TypeError on typed nullable properties such as Question::$points)
+				}
 			} elseif ($object->fields[$key]['type'] == 'boolean') {
 				$value = ((GETPOST($key, 'aZ09') == 'on' || GETPOST($key, 'aZ09') == '1') ? 1 : 0);
 			} elseif ($object->fields[$key]['type'] == 'reference') {


### PR DESCRIPTION
@
Closes #2423

## Problème

Erreur fatale en modification/création dune question lorsque le champ **Points** est laissé vide :

```
PHP Fatal error: Uncaught TypeError: Typed property Question::$points must be float or null, string used in view/question/question_card.php:559
```

## Cause racine

- `class/question.class.php` : `public ?float $points;` (typage strict).
- Champ de type `real`, `notnull => 0`.
- Dans la boucle générique de `question_card.php`, `price2num(GETPOST($key, alphanohtml))` renvoie la **chaîne vide** `` quand le champ est vide.
- Laffectation `$object->points = ` est rejetée par PHP 8 (`` non convertible en `float|null`) → fatal.

## Correctif

Normalisation dun résultat `price2num` vide en `null` dans **les deux** branches numériques de la carte (actions create et update). `null` est sémantiquement correct pour un champ `notnull => 0` et compatible avec la propriété typée nullable.

## Vérifications

- `php -l view/question/question_card.php` → *No syntax errors detected*.
- Repro isolée confirmée : `$points = ` → TypeError (identique à la prod) ; `$points = null` → OK ; `$points = "3"` → `3.0` (coercion inchangée pour une saisie normale).

> NB : base `develop`, donc `Closes #2423` ne fermera pas lissue automatiquement — à clôturer manuellement après merge.
@