### PR TITLE
#2427 [Task] feat: assign user to task from creation modal

### DIFF
--- a/class/question.class.php
+++ b/class/question.class.php
@@ -922,7 +922,7 @@ class Question extends SaturneObject
      */
     public function displayInSheetCard(Sheet $sheetObject, string $positionPath, string $tdOffsetStyle = '')
     {
-		global $langs;
+		global $conf, $langs;
 		$question = $this;
         require __DIR__ . '/../view/sheet/sheet_question.tpl.php';
     }

--- a/core/tpl/answers/answers_task_view.tpl.php
+++ b/core/tpl/answers/answers_task_view.tpl.php
@@ -41,6 +41,9 @@
                 <div class="question__action-metas">
                     <span class="question__action-metas-ref"><?php echo $taskInfos['task']['ref']; ?></span>
                     <span class="question__action-metas-author"><?php echo $taskInfos['task']['author']; ?></span>
+                    <?php if (!empty($taskInfos['task']['assigned'])) : ?>
+                        <span class="question__action-metas-assigned"><i class="fas fa-user-check pictofixedwidth"></i><?php echo implode(', ', $taskInfos['task']['assigned']); ?></span>
+                    <?php endif; ?>
                     <span class="question__action-metas-date"><i class="fas fa-calendar-alt pictofixedwidth"></i><?php echo $taskInfos['task']['date']; ?></span>
                     <div class="modal-open">
                         <?php if (!empty($permissionToManageTaskTimeSpent)) : ?>

--- a/core/tpl/digiquali_answers_task_action.tpl.php
+++ b/core/tpl/digiquali_answers_task_action.tpl.php
@@ -48,7 +48,10 @@ if ($action == 'add_task' && !empty($permissionToAddTask)) {
     $task->budget_amount  = $data['budget_amount'] ?? null;
     $task->fk_task_parent = !empty($object->fk_master_task) ? $object->fk_master_task : 0;
 
-    $task->create($user);
+    $taskId = $task->create($user);
+    if ($taskId > 0 && !empty($data['fk_user_assign'])) {
+        $task->add_contact($data['fk_user_assign'], 'TASKEXECUTIVE', 'internal');
+    }
     $task->add_object_linked($data['objectLine_element'], $data['objectLine_id']);
     // @todo manage error
 }

--- a/core/tpl/modal/modal_task_add.tpl.php
+++ b/core/tpl/modal/modal_task_add.tpl.php
@@ -24,7 +24,7 @@
 /**
  * The following vars must be defined:
  * Global   : $langs
- * Objects  : $object
+ * Objects  : $object, $form
  * Variable : $taskNextValue
  */ ?>
 
@@ -43,24 +43,28 @@
                         <span class="title"><?php echo $langs->trans('Label'); ?></span>
                         <input type="text" id="answer-task-label" name="label">
                     </label>
+                    <label>
+                        <span class="title"><?php echo $langs->trans('AffectedTo'); ?></span>
+                        <?php echo $form->select_dolusers('', 'answer-task-assigned-user', 1); ?>
+                    </label>
                     <div class="answer-task-date wpeo-gridlayout grid-3">
                         <div>
                             <label>
                                 <span class="title"><?php echo $langs->trans('DateStart'); ?></span>
                                 <input type="datetime-local" id="answer-task-start-date" name="date_start" value="<?php echo dol_print_date(dol_now('tzuser'), '%Y-%m-%dT%H:%M'); ?>">
-                            <label>
+                            </label>
                         </div>
                         <div>
                             <label>
                                 <span class="title"><?php echo $langs->trans('Deadline'); ?></span>
                                 <input type="datetime-local" id="answer-task-end-date" name="date_end">
-                            <label>
+                            </label>
                         </div>
                         <div>
                             <label>
                                 <span class="title"><?php echo $langs->trans('Budget'); ?></span>
                                 <input type="number" id="answer-task-budget" name="budget" min="0">
-                            <label>
+                            </label>
                         </div>
                     </div>
                 </div>

--- a/css/scss/modal/_modal.scss
+++ b/css/scss/modal/_modal.scss
@@ -1,1 +1,2 @@
 @import "riskassessment-add";
+@import "task-add";

--- a/css/scss/modal/_task-add.scss
+++ b/css/scss/modal/_task-add.scss
@@ -1,0 +1,62 @@
+.modal-answer-task-add {
+  .answer-task {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25em;
+    padding-top: 0.5em;
+  }
+
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4em;
+    margin: 0;
+
+    .title {
+      font-weight: 600;
+      color: $color__secondary;
+    }
+  }
+
+  input[type="text"],
+  input[type="number"],
+  input[type="datetime-local"],
+  select {
+    width: 100%;
+    height: 38px;
+    padding: 0 0.75em;
+    border: 1px solid var(--inputbordercolor);
+    border-radius: 8px;
+    background: #fff;
+    box-shadow: none;
+    transition: border-color 0.15s ease-out, box-shadow 0.15s ease-out;
+
+    &:focus {
+      border-color: $color__primary;
+      box-shadow: 0 0 0 2px rgba($color__primary, 0.15);
+      outline: none;
+    }
+  }
+
+  // select2 rendered by select_dolusers
+  .select2-container {
+    width: 100% !important;
+
+    .select2-selection--single {
+      height: 38px;
+      border: 1px solid var(--inputbordercolor);
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+
+      .select2-selection__rendered {
+        line-height: normal;
+        padding-left: 0.25em;
+      }
+
+      .select2-selection__arrow {
+        height: 36px;
+      }
+    }
+  }
+}

--- a/js/modules/task.js
+++ b/js/modules/task.js
@@ -182,8 +182,9 @@ window.digiquali.task.createTask = function() {
   const label     = $modal.find('#answer-task-label').val();
   const startDate = $modal.find('#answer-task-start-date').val();
   const endDate   = $modal.find('#answer-task-end-date').val();
-  const budget    = $modal.find('#answer-task-budget').val();
-  const projectId = $modal.data('project-id');
+  const budget         = $modal.find('#answer-task-budget').val();
+  const projectId      = $modal.data('project-id');
+  const assignedUserId = $modal.find('[name="answer-task-assigned-user"]').val();
 
   $.ajax({
     url: `${document.URL}&action=add_task&token=${token}`,
@@ -196,7 +197,8 @@ window.digiquali.task.createTask = function() {
       date_start:         startDate,
       date_end:           endDate,
       budget_amount:      budget,
-      fk_project:         projectId
+      fk_project:         projectId,
+      fk_user_assign:     assignedUserId
     }),
     success: function(resp) {
       $modal.replaceWith($(resp).find('#answer_task_add'));

--- a/lib/digiquali_control.lib.php
+++ b/lib/digiquali_control.lib.php
@@ -363,6 +363,15 @@ function get_task_infos(Task $task): array
     $userTmp->fetch($task->fk_user_creat);
     $out['task']['author'] = $userTmp->getNomUrl(1);
 
+    $out['task']['assigned'] = [];
+    $assignedContacts = $task->liste_contact(-1, 'internal', 0, 'TASKEXECUTIVE');
+    if (is_array($assignedContacts)) {
+        foreach ($assignedContacts as $assignedContact) {
+            $userTmp->fetch($assignedContact['id']);
+            $out['task']['assigned'][] = $userTmp->getNomUrl(1);
+        }
+    }
+
     if (empty($task->date_start) && empty($task->date_end)) {
         $out['task']['date'] = dol_print_date($task->date_c, 'dayhour');
     } else {

--- a/view/control/control_card.php
+++ b/view/control/control_card.php
@@ -65,7 +65,7 @@ if (isModEnabled('dolicar')) {
 global $conf, $db, $hookmanager, $langs, $user;
 
 // Load translation files required by the page
-saturne_load_langs(['other', 'bills', 'orders']);
+saturne_load_langs(['other', 'bills', 'orders', 'projects']);
 
 // Get parameters
 $id                  = GETPOST('id', 'int');


### PR DESCRIPTION
## Changements
- Ajout d'un sélecteur « Affecté à » (utilisateur interne, optionnel) dans la modal de création de tâche de la fiche contrôle.
- Affectation de l'utilisateur choisi comme responsable (contact interne `TASKEXECUTIVE`) à la création de la tâche (`add_contact(userid, 'TASKEXECUTIVE', 'internal')`).
- Rework du CSS de la modal pour l'aligner sur le thème des autres modals digiquali (labels en gras, inputs/select2 pleine largeur, bordure + radius cohérents, focus bleu) + correction de 3 balises `</label>` mal fermées qui cassaient la mise en page.
- Affichage de la personne affectée sur la carte de tâche, à côté de l'auteur.
- Correctif du warning `Undefined variable $conf` dans `question.class.php` (méthode `displayInSheetCard`).

## Fichiers modifiés
- `view/control/control_card.php`
- `core/tpl/modal/modal_task_add.tpl.php`
- `js/modules/task.js`
- `core/tpl/digiquali_answers_task_action.tpl.php`
- `css/scss/modal/_task-add.scss` (nouveau)
- `css/scss/modal/_modal.scss`
- `lib/digiquali_control.lib.php`
- `core/tpl/answers/answers_task_view.tpl.php`
- `class/question.class.php`

## Notes
- Les fichiers compilés `css/digiquali.min.css` / `js/digiquali.min.js` ne sont volontairement pas commités (régénérés par la CI).

## Issue
Closes #2427

🤖 Generated with [Claude Code](https://claude.com/claude-code)
