### PR TITLE
#2429 [Task] feat: voir et modifier l'avancement des tâches depuis la liste

### DIFF
--- a/core/tpl/answers/answers_task_view.tpl.php
+++ b/core/tpl/answers/answers_task_view.tpl.php
@@ -58,6 +58,13 @@
                         </div>
                     <?php endif; ?>
                     <span class="question__action-metas-budget"><i class="fas fa-coins pictofixedwidth"></i><?php echo $taskInfos['task']['budget']; ?></span>
+                    <span class="question__action-metas-progress">
+                        <i class="fas fa-tasks pictofixedwidth"></i>
+                        <?php if (!empty($permissionToAddTask)) : ?>
+                            <input type="range" class="range task-progress-slider" min="0" max="100" step="1" value="<?php echo (int) $taskInfos['task']['progress']; ?>" data-task-id="<?php echo $task->id; ?>">
+                        <?php endif; ?>
+                        <span class="task-progress-value"><?php echo (int) $taskInfos['task']['progress']; ?> %</span>
+                    </span>
                 </div>
                 <div class="question__action-content"><?php echo $taskInfos['task']['label']; ?></div>
             </div>

--- a/core/tpl/digiquali_answers_task_action.tpl.php
+++ b/core/tpl/digiquali_answers_task_action.tpl.php
@@ -75,9 +75,26 @@ if ($action == 'update_task' && !empty($permissionToAddTask)) {
         $task->date_end = dol_stringtotime($data['date_end']);
     }
     $task->budget_amount = $data['budget'];
+    if (isset($data['progress'])) {
+        $task->progress = max(0, min(100, (int) $data['progress']));
+    }
 
     $task->update($user);
     // @todo manage error
+}
+
+if ($action == 'update_task_progress' && !empty($permissionToAddTask)) {
+    $data = json_decode(file_get_contents('php://input'), true);
+    $task->fetch($data['task_id']);
+
+    $task->progress = max(0, min(100, (int) $data['progress']));
+
+    $result = $task->update($user);
+    if ($result < 0) {
+        // Update task progress KO
+        header('HTTP/1.1 500 Internal Server');
+        die(json_encode(['message' => $langs->transnoentities($task->error), 'code' => '1337']));
+    }
 }
 
 if ($action == 'delete_task' && !empty($permissionToDeleteTask)) {

--- a/core/tpl/modal/modal_task_edit.tpl.php
+++ b/core/tpl/modal/modal_task_edit.tpl.php
@@ -44,7 +44,6 @@ $taskInfos = get_task_infos($task); ?>
                 <span class="answer-task-date"><i class="fas fa-calendar-alt pictofixedwidth"></i><?php echo $taskInfos['task']['date']; ?></span>
                 <span class="answer-total-task-timespent"><i class="fas fa-clock pictofixedwidth"></i><?php echo $taskInfos['task']['time']; ?></span>
                 <span><i class="fas fa-coins pictofixedwidth"></i><?php echo $taskInfos['task']['budget']; ?></span>
-                <span class="answer-task-progress <?php //echo $task->getTaskProgressColorClass($task_progress); ?>"><?php echo $taskInfos['task']['progress'] ? $taskInfos['task']['progress'] . " %" : 0 . " %" ?></span>
             </div>
             <div class="answer-task-content">
                 <div class="answer-task-title">
@@ -72,6 +71,15 @@ $taskInfos = get_task_infos($task); ?>
                             <input type="number" id="answer-task-budget" name="budget" min="0" value="<?php echo $task->budget_amount; ?>">
                         </label>
                     </div>
+                </div>
+                <div class="answer-task-progress-field">
+                    <label>
+                        <span class="title"><?php echo $langs->trans('Progress'); ?></span>
+                        <div class="answer-task-progress-control">
+                            <input type="range" id="answer-task-progress" class="range" name="progress" min="0" max="100" step="1" value="<?php echo (int) $task->progress; ?>">
+                            <span class="task-progress-value"><?php echo (int) $task->progress; ?> %</span>
+                        </div>
+                    </label>
                 </div>
             </div>
         </div>

--- a/css/scss/modal/_modal.scss
+++ b/css/scss/modal/_modal.scss
@@ -1,2 +1,3 @@
 @import "riskassessment-add";
 @import "task-add";
+@import "task-edit";

--- a/css/scss/modal/_task-edit.scss
+++ b/css/scss/modal/_task-edit.scss
@@ -1,0 +1,71 @@
+.modal-answer-task-edit {
+  .answer-task-progress-field {
+    label {
+      display: flex;
+      flex-direction: column;
+      gap: 0.4em;
+      margin: 0;
+
+      .title {
+        font-weight: 600;
+        color: $color__secondary;
+      }
+    }
+
+    .answer-task-progress-control {
+      display: flex;
+      align-items: center;
+      gap: 0.75em;
+
+      input[type="range"] {
+        flex: 1;
+        appearance: none;
+        -webkit-appearance: none;
+        height: 8px;
+        padding: 0;
+        border: 0;
+        outline: none;
+        margin: 0;
+        background: transparent;
+        cursor: pointer;
+
+        &::-webkit-slider-runnable-track {
+          height: 8px;
+          border-radius: 50px;
+          background: linear-gradient(90deg, #D53C3D 0%, #ED911D 25%, #F2C32E 50%, #92D444 75%, #57AD39 100%);
+        }
+        &::-webkit-slider-thumb {
+          appearance: none;
+          -webkit-appearance: none;
+          width: 18px;
+          height: 18px;
+          margin-top: -5px;
+          border: 3px solid #fff;
+          border-radius: 50%;
+          background: $color__primary;
+          box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+        }
+        &::-moz-range-track {
+          height: 8px;
+          border-radius: 50px;
+          background: linear-gradient(90deg, #D53C3D 0%, #ED911D 25%, #F2C32E 50%, #92D444 75%, #57AD39 100%);
+        }
+        &::-moz-range-thumb {
+          width: 18px;
+          height: 18px;
+          border: 3px solid #fff;
+          border-radius: 50%;
+          background: $color__primary;
+          box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+        }
+      }
+
+      .task-progress-value {
+        min-width: 42px;
+        text-align: right;
+        font-weight: 600;
+        color: $color__secondary;
+      }
+    }
+  }
+}

--- a/css/scss/page/answer/_answer.scss
+++ b/css/scss/page/answer/_answer.scss
@@ -443,6 +443,61 @@
             i {
               color: rgba($color__public-primary, 0.5)
             }
+
+            .question__action-metas-progress {
+              display: inline-flex;
+              align-items: center;
+              gap: 0.35em;
+
+              .task-progress-slider {
+                width: 70px;
+                appearance: none;
+                -webkit-appearance: none;
+                height: 6px;
+                padding: 0;
+                border: 0;
+                outline: none;
+                margin: 0;
+                background: transparent;
+                cursor: pointer;
+
+                &::-webkit-slider-runnable-track {
+                  height: 6px;
+                  border-radius: 50px;
+                  background: linear-gradient(90deg, #D53C3D 0%, #ED911D 25%, #F2C32E 50%, #92D444 75%, #57AD39 100%);
+                }
+                &::-webkit-slider-thumb {
+                  appearance: none;
+                  -webkit-appearance: none;
+                  width: 14px;
+                  height: 14px;
+                  margin-top: -4px;
+                  border: 2px solid #fff;
+                  border-radius: 50%;
+                  background: $color__primary;
+                  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+                }
+                &::-moz-range-track {
+                  height: 6px;
+                  border-radius: 50px;
+                  background: linear-gradient(90deg, #D53C3D 0%, #ED911D 25%, #F2C32E 50%, #92D444 75%, #57AD39 100%);
+                }
+                &::-moz-range-thumb {
+                  width: 14px;
+                  height: 14px;
+                  border: 2px solid #fff;
+                  border-radius: 50%;
+                  background: $color__primary;
+                  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+                }
+              }
+
+              .task-progress-value {
+                font-weight: 600;
+                color: $color__public-primary;
+                white-space: nowrap;
+              }
+            }
           }
         }
         .question__action-buttons {

--- a/js/modules/task.js
+++ b/js/modules/task.js
@@ -71,6 +71,10 @@ window.digiquali.task.event = function initializeEvents() {
 
   $(document).on('change', '.question__action-check input[type="checkbox"]', window.digiquali.task.checkTask);
 
+  // Task progress event
+  $(document).on('input', '.task-progress-slider, #answer-task-progress', window.digiquali.task.refreshProgressLabel);
+  $(document).on('change', '.task-progress-slider', window.digiquali.task.updateTaskProgress);
+
   $(document).on('click', '.modal-open', window.digiquali.task.autoFocusLabel);
 
   // Task timespent event
@@ -222,12 +226,13 @@ window.digiquali.task.updateTask = function() {
   const $modal = $this.closest('#answer_task_edit');
   const $form  = $modal.find('.answer-task-content');
   const taskId = $this.data('task-id');
-  const $list  = $(document).find(`#answer_task${taskId} .question__action-body`);
+  const $task  = $(document).find(`#answer_task${taskId}`);
 
   const label     = $form.find('#answer-task-label').val();
   const startDate = $form.find('#answer-task-start-date').val();
   const endDate   = $form.find('#answer-task-end-date').val();
   const budget    = $form.find('#answer-task-budget').val();
+  const progress  = $form.find('#answer-task-progress').val();
 
   $.ajax({
     url: `${document.URL}&action=update_task&token=${token}`,
@@ -238,11 +243,12 @@ window.digiquali.task.updateTask = function() {
       label:      label,
       date_start: startDate,
       date_end:   endDate,
-      budget:     budget
+      budget:     budget,
+      progress:   progress
     }),
     success: function(resp) {
       $modal.removeClass('modal-active');
-      $list.replaceWith($(resp).find(`#answer_task${taskId} .question__action-body`));
+      $task.replaceWith($(resp).find(`#answer_task${taskId}`));
     }
   });
 };
@@ -305,6 +311,50 @@ window.digiquali.task.checkTask = function() {
   $.ajax({
     url: `${document.URL}&action=check_task&task_id=${taskId}&token=${token}`,
     type: 'POST',
+    success: function(resp) {
+      $task.replaceWith($(resp).find(`#answer_task${taskId}`));
+    }
+  });
+};
+
+/**
+ * Refresh the displayed progress value while dragging the slider
+ *
+ * @since   20.2.0
+ * @version 20.2.0
+ *
+ * @return {void}
+ */
+window.digiquali.task.refreshProgressLabel = function() {
+  const $this = $(this);
+  $this.siblings('.task-progress-value').text(`${$this.val()} %`);
+};
+
+/**
+ * Update task progress on the fly from the inline slider
+ *
+ * @since   20.2.0
+ * @version 20.2.0
+ *
+ * @return {void}
+ */
+window.digiquali.task.updateTaskProgress = function() {
+  const token = window.saturne.toolbox.getToken();
+
+  const $this    = $(this);
+  const taskId   = $this.data('task-id');
+  const progress = $this.val();
+  const $task    = $(document).find(`#answer_task${taskId}`);
+
+  window.saturne.loader.display($task);
+  $.ajax({
+    url: `${document.URL}&action=update_task_progress&token=${token}`,
+    type: 'POST',
+    contentType: 'application/json; charset=utf-8',
+    data: JSON.stringify({
+      task_id:  taskId,
+      progress: progress
+    }),
     success: function(resp) {
       $task.replaceWith($(resp).find(`#answer_task${taskId}`));
     }


### PR DESCRIPTION
## Changements

- Curseur d'avancement (0–100) dans la modale d'édition de tâche, avec valeur affichée en direct
- Curseur inline « à la volée » dans la liste des tâches (sauvegarde au relâchement), placé à droite du montant ; le pourcentage est visible même en lecture seule
- JS : envoi de `progress` depuis la modale, mise à jour live du libellé, sauvegarde inline ; resynchronisation de la carte de tâche (case à cocher incluse)
- Serveur : `update_task` gère désormais `progress` (borné 0–100) + nouvelle action `update_task_progress` pour la sauvegarde inline
- SCSS : style des curseurs (dégradé rouge→vert), compact dans la liste

## Fichiers modifiés

- `core/tpl/answers/answers_task_view.tpl.php`
- `core/tpl/modal/modal_task_edit.tpl.php`
- `core/tpl/digiquali_answers_task_action.tpl.php`
- `js/modules/task.js`
- `css/scss/page/answer/_answer.scss`
- `css/scss/modal/_modal.scss`
- `css/scss/modal/_task-edit.scss` (nouveau)

## Issue

#2429

🤖 Generated with [Claude Code](https://claude.com/claude-code)
