### PR TITLE
#2426 [Control] feat: attach documents to a question answer

### DIFF
--- a/core/tpl/digiquali_question_single.tpl.php
+++ b/core/tpl/digiquali_question_single.tpl.php
@@ -64,9 +64,12 @@ if (!isset($user->conf->DIGIQUALI_SHOW_ONLY_QUESTIONS_WITH_NO_ANSWER) || empty($
                         <div class="question__answer-actions">
                             <?php if ($question->authorize_answer_photo > 0) : ?>
                                 <?php echo saturne_render_media_block('digiquali', $object->element . '/' . $object->ref . '/answer_photo/' . $question->ref, 'answer_photo_' . $question->id, '', [
-                                    'show_photo'  => true,
-                                    'show_audio'  => false,
-                                    'show_upload' => $object->status == 0,
+                                    'show_photo'       => true,
+                                    'show_audio'       => false,
+                                    'show_file'        => $object->element === 'control',
+                                    'file_sub_dir'     => ($objectLine->id > 0 ? 'controldet/' . dol_sanitizeFileName($objectLine->ref) : ''),
+                                    'file_upload_data' => ['fk_control' => $object->id, 'fk_question' => $question->id],
+                                    'show_upload'      => $object->status == 0,
                                 ]); ?>
                             <?php endif; ?>
                             <?php if (!empty($object->project) && !empty($permissionToAddTask)) : ?>

--- a/view/control/control_card.php
+++ b/view/control/control_card.php
@@ -168,7 +168,7 @@ if (empty($resHook)) {
     $error = 0;
 
     // Block content-modifying actions on read-only (locked/archived) objects
-    $modifyingActions = ['set_categories', 'confirm_setVerdict', 'confirm_set_reopen', 'uploadPhoto', 'save', 'update'];
+    $modifyingActions = ['set_categories', 'confirm_setVerdict', 'confirm_set_reopen', 'uploadPhoto', 'uploadFile', 'deleteFile', 'save', 'update'];
     if ((in_array($action, $modifyingActions) || preg_match('/^set[a-z]/', $action)) && isset($object->status) && !$object->isModifiable()) {
         setEventMessages($langs->trans('ObjectIsReadOnly', ucfirst($langs->transnoentities('The' . ucfirst($object->element)))), [], 'warnings');
         $action = '';
@@ -345,6 +345,57 @@ if (empty($resHook)) {
             } else {
                 $allowOverwrite = GETPOSTINT('overwrite') ? 1 : 0;
                 dol_add_file_process($uploadDir, $allowOverwrite, 1, 'userfile', '', null, '', 1);
+            }
+        }
+    }
+
+    // Action to upload a document into the answer (controldet) linked files via the media block AJAX upload
+    if ($action == 'uploadFile' && !empty($conf->global->MAIN_UPLOAD_DOC)) {
+        $fkControl  = GETPOSTINT('fk_control');
+        $fkQuestion = GETPOSTINT('fk_question');
+
+        if ($fkControl > 0 && $fkQuestion > 0) {
+            // Resolve the answer line; create it on the fly so a document can be attached before answering
+            $answerLine = new ControlLine($db);
+            $resLines   = $answerLine->fetchFromParentWithQuestion($fkControl, $fkQuestion);
+            if (is_array($resLines) && !empty($resLines)) {
+                $answerLine = array_shift($resLines);
+            } else {
+                $answerLine->fk_control    = $fkControl;
+                $answerLine->fk_question   = $fkQuestion;
+                $answerLine->status        = ControlLine::STATUS_VALIDATED;
+                $answerLine->date_creation = dol_now();
+                $answerLine->create($user);
+            }
+
+            if ($answerLine->id > 0) {
+                $uploadDir = $conf->digiquali->dir_output . '/controldet/' . dol_sanitizeFileName($answerLine->ref);
+                if (!dol_is_dir($uploadDir)) {
+                    dol_mkdir($uploadDir);
+                }
+
+                $allowOverwrite = GETPOSTINT('overwrite') ? 1 : 0;
+                dol_add_file_process($uploadDir, $allowOverwrite, 1, 'userfile', '', null, '', 1);
+            }
+        }
+    }
+
+    // Action to delete a document from the answer (controldet) linked files via the media block AJAX upload
+    if ($action == 'deleteFile') {
+        $uploadModuleName = GETPOST('module_name', 'alpha');
+        $uploadSubDir     = GETPOST('sub_dir', 'alpha');
+        $fileName         = dol_sanitizeFileName(GETPOST('filename', 'alpha'));
+
+        if (!empty($uploadModuleName) && !empty($fileName) && !empty($uploadSubDir) && strpos($uploadSubDir, '..') === false) {
+            $uploadModuleNameLowerCase = dol_strtolower($uploadModuleName);
+            $uploadDir                 = !empty($conf->$uploadModuleNameLowerCase->dir_output)
+                ? $conf->$uploadModuleNameLowerCase->dir_output
+                : $conf->ecm->dir_output . '/' . $uploadModuleNameLowerCase;
+            $uploadDir                .= '/' . $uploadSubDir;
+
+            $filePath = $uploadDir . '/' . $fileName;
+            if (dol_is_file($filePath)) {
+                dol_delete_file($filePath);
             }
         }
     }


### PR DESCRIPTION
Closes #2426

## Objectif

Permettre de joindre **n'importe quel document** sur une question dans une fiche de contrôle, au même endroit que les photos de réponse.

## Comportement

- Le document est stocké dans les **fichiers joints de la réponse** (`ControlLine` / `controldet`), via la nouvelle section `show_file` du bloc média générique de Saturne.
- Il apparaît donc dans l'onglet **Fichiers joints** de la réponse (`controldet_card`).
- Affichage compact : un bouton d'upload + un badge du nombre de fichiers ouvrant une modal (téléchargement + suppression).
- La ligne de réponse est **créée à la volée** si on joint un document avant d'avoir répondu à la question.
- Périmètre **contrôle uniquement** ; upload/suppression seulement en brouillon.

## Dépendance

⚠️ Nécessite **Evarisk/Saturne#1395** (la brique générique `show_file` du bloc média). À merger d'abord côté Saturne.