### PR TITLE
#2432 [Element] fix: php8 warnings, percent score display and single-line editable badges

### DIFF
--- a/class/riskassessment.class.php
+++ b/class/riskassessment.class.php
@@ -361,7 +361,7 @@ class RiskAssessment extends SaturneObject
     {
         global $db, $langs;
 
-        if ($riskAssessmentInfos['id'] > 0) {
+        if (($riskAssessmentInfos['id'] ?? 0) > 0) {
             require __DIR__ . '/../core/tpl/riskassessment/digiquali_riskassessment_single_view.tpl.php';
         } else {
             require __DIR__ . '/../core/tpl/riskassessment/digiquali_riskassessment_add_view.tpl.php';
@@ -372,7 +372,7 @@ class RiskAssessment extends SaturneObject
     {
         global $db, $langs;
 
-        if ($riskAssessmentInfos['id'] > 0) {
+        if (($riskAssessmentInfos['id'] ?? 0) > 0) {
             require __DIR__ . '/../core/tpl/riskassessment/task/digiquali_riskassessment_task_single_view.tpl.php';
         } else {
             require __DIR__ . '/../core/tpl/riskassessment/task/digiquali_riskassessment_task_add_view.tpl.php';

--- a/css/scss/page/_digiqualielement.scss
+++ b/css/scss/page/_digiqualielement.scss
@@ -1,0 +1,8 @@
+// Score badges (ActualScore / TargetScore) show a "%" sign after the value.
+// The value stays editable (contenteditable), but the sign is rendered as a
+// pseudo-element so it can never be edited or saved as part of the value.
+.badge-percent {
+  .badge__detail::after {
+    content: '\00a0%';
+  }
+}

--- a/css/scss/page/_page.scss
+++ b/css/scss/page/_page.scss
@@ -1,4 +1,5 @@
 @import "control";
+@import "digiqualielement";
 @import "element-medias";
 @import "question-add";
 @import "public-answer";

--- a/js/modules/activity.js
+++ b/js/modules/activity.js
@@ -53,6 +53,7 @@ window.digiquali.activity.init = function init() {
 window.digiquali.activity.event = function initializeEvents() {
   $(document).on('input', '#label', window.digiquali.activity.updateModalActivityButton);
   $(document).on('blur', '.activity-list-container [contenteditable="true"]', window.digiquali.activity.updateContentEditable);
+  $(document).on('keydown', '.activity-list-container [contenteditable="true"]', window.digiquali.activity.preventLineBreak);
 
   // Events for create activity
   $(document).on('click', '#activity_add', function createActivity() {
@@ -78,6 +79,23 @@ window.digiquali.activity.updateModalActivityButton = function() {
     $button.removeClass('button-disable');
   } else {
     $button.addClass('button-disable');
+  }
+};
+
+/**
+ * Prevent line breaks in editable badges: Enter exits the field (which triggers the save on blur)
+ * instead of inserting a new line that would break the badge layout.
+ *
+ * @since   21.3.0
+ * @version 21.3.0
+ *
+ * @param  {Event} e - The keydown event
+ * @return {void}
+ */
+window.digiquali.activity.preventLineBreak = function(e) {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    $(this).blur();
   }
 };
 

--- a/view/digiqualielement/digiqualielement_view.php
+++ b/view/digiqualielement/digiqualielement_view.php
@@ -191,12 +191,15 @@ if ((empty($action) || ($action != 'edit' && $action != 'create'))) {
         print '<input type="hidden" id="success_message" value="' . $langs->transnoentities('Updated') . '">';
         print '<div class="activity-container__body wpeo-gridlayout grid-2">';
         foreach ($activitySingle->fields as $key => $val) {
-            if (!isset($val['viewmode']) && $val['viewmode'] != 'badge') {
+            if (!isset($val['viewmode']) || $val['viewmode'] != 'badge') {
                 continue;
             }
+            // Score fields show a non-editable percentage sign, rendered via CSS ::after on .badge-percent
+            $badgeClassName = (in_array($key, ['score', 'target_score'], true) && isset($activitySingle->{$key})) ? 'badge-percent' : '';
             echo saturne_get_badge_component_html([
                 'id'        => 'badge_component_' . $key . '_' . $activitySingle->id,
                 'field'     => $key,
+                'className' => $badgeClassName,
                 'iconClass' => $val['picto'] ?? '',
                 'title'     => $val['label'],
                 'details'   => [$activitySingle->{$key} ?? $langs->transnoentities('NotKnown')],


### PR DESCRIPTION
## Changements

- Warning PHP 8 « Undefined array key 'viewmode' » corrigé (`&&` → `||`) dans la boucle des badges d'activité (`digiqualielement_view.php`)
- Warning PHP 8 « Undefined array key 'id' » corrigé (`?? 0`) dans `displayRiskAssessmentView` / `displayRiskAssessmentTaskView`
- Scores (actuel / cible) affichés en pourcentage via un pseudo-élément CSS `::after` **non éditable** — le `%` n'est ni modifiable ni inclus dans la valeur sauvegardée, et n'apparaît que si le score a une valeur
- Badges d'activité éditables : la touche **Entrée sort du champ** (et déclenche la sauvegarde existante) au lieu d'insérer un saut de ligne → plus de bug visuel multi-ligne

## Fichiers modifiés

- `view/digiqualielement/digiqualielement_view.php`
- `class/riskassessment.class.php`
- `js/modules/activity.js`
- `css/scss/page/_digiqualielement.scss` (nouveau)
- `css/scss/page/_page.scss`

## Issue

#2432

🤖 Generated with [Claude Code](https://claude.com/claude-code)
