### PR TITLE
[Medias] fix: undefined variable $confName on answer photo media size

### DIFF
--- a/class/actions_digiquali.class.php
+++ b/class/actions_digiquali.class.php
@@ -599,11 +599,12 @@ class ActionsDigiquali
                             $object->fetchObjectLinked($object->fk_sheet, 'digiquali_sheet');
                             $questionsLinked = $object->linkedObjects;
                             $linkedMedias    = 0;
+                            $confName        = 'DIGIQUALI_' . dol_strtoupper($object->element) . '_USE_LARGE_MEDIA_IN_GALLERY';
 
                             if (is_array($questionsLinked['digiquali_question']) && !empty($questionsLinked['digiquali_question'])) {
                                 foreach ($questionsLinked['digiquali_question'] as $questionLinked) {
                                     if ($questionLinked->authorize_answer_photo > 0) {
-                                        saturne_show_medias_linked('digiquali', $conf->digiquali->multidir_output[$conf->entity] . '/' . $object->element . '/' . $object->ref . '/answer_photo/' . $questionLinked->ref, ($conf->global->$confName ? 'large' : 'medium'), '', 0, 0, 0, 200, 200, 0, 0, 0, $object->element . '/' . $object->ref . '/answer_photo/' . $questionLinked->ref, $object, '', 0, 0);
+                                        saturne_show_medias_linked('digiquali', $conf->digiquali->multidir_output[$conf->entity] . '/' . $object->element . '/' . $object->ref . '/answer_photo/' . $questionLinked->ref, (getDolGlobalInt($confName) ? 'large' : 'medium'), '', 0, 0, 0, 200, 200, 0, 0, 0, $object->element . '/' . $object->ref . '/answer_photo/' . $questionLinked->ref, $object, '', 0, 0);
                                         $linkedMedias += $object->nbphoto;
                                     }
                                 }

--- a/view/object_medias.php
+++ b/view/object_medias.php
@@ -100,15 +100,15 @@ if ($id > 0 || !empty($ref)) {
     $questionIds     = $object->linkedObjectsIds;
     $questionsLinked = $object->linkedObjects;
     $linkedMedias    = 0;
+    $confName        = 'DIGIQUALI_' . dol_strtoupper($object->element) . '_USE_LARGE_MEDIA_IN_GALLERY';
 
     if (is_array($questionsLinked['digiquali_question']) && !empty($questionsLinked['digiquali_question'])) {
         foreach ($questionsLinked['digiquali_question'] as $questionLinked) {
             if ($questionLinked->authorize_answer_photo > 0) {
-                $photo = saturne_show_medias_linked('digiquali', $conf->digiquali->multidir_output[$conf->entity] . '/' . $object->element . '/' . $object->ref . '/answer_photo/' . $questionLinked->ref, ($conf->global->$confName ? 'large' : 'medium'), '', 0, 0, 0, 200, 200, 0, 0, 0, $object->element . '/' . $object->ref . '/answer_photo/' . $questionLinked->ref, $object, '', 0, 0);
+                $photo = saturne_show_medias_linked('digiquali', $conf->digiquali->multidir_output[$conf->entity] . '/' . $object->element . '/' . $object->ref . '/answer_photo/' . $questionLinked->ref, (getDolGlobalInt($confName) ? 'large' : 'medium'), '', 0, 0, 0, 200, 200, 0, 0, 0, $object->element . '/' . $object->ref . '/answer_photo/' . $questionLinked->ref, $object, '', 0, 0);
                 print '<div class="question-section">';
                 print '<span class="question-ref">' . $questionLinked->getNomUrl(0, '', 1, '', -1, 1) . (empty($object->nbphoto) ? ' - ' . $langs->transnoentities('NoPhotoYet') : '') . '</span>';
                 print '<div class="table-cell table-full linked-medias answer_photo">';
-                $confName = 'DIGIQUALI_' . dol_strtoupper($object->element) . '_USE_LARGE_MEDIA_IN_GALLERY';
                 if (!empty($object->nbphoto)) {
                     print $photo;
                 }


### PR DESCRIPTION
## Problème

Une variable `$confName` était utilisée **avant d'être définie**, ce qui génère un warning PHP et fausse la taille d'affichage des photos de réponse :

- `class/actions_digiquali.class.php` (`ActionsDigiquali::completeTabsHead()`) : `$confName` n'était **jamais défini** → `Warning: Undefined variable $confName` à chaque rendu du badge de l'onglet *Médias*, et la taille était toujours forcée à `medium`.
- `view/object_medias.php` : `$confName` était défini **après** son utilisation dans la boucle → warning à la première itération + logique de taille incorrecte.

```
Warning: Undefined variable $confName in .../class/actions_digiquali.class.php on line 606
```

## Correctif

- Définition de `$confName = 'DIGIQUALI_' . dol_strtoupper($object->element) . '_USE_LARGE_MEDIA_IN_GALLERY'` **avant** son utilisation, dans les deux fichiers.
- Lecture via `getDolGlobalInt($confName)` (idiomatique Dolibarr) au lieu de `$conf->global->$confName`, ce qui évite aussi tout warning de propriété indéfinie.

## Effet

- Plus de warning `Undefined variable $confName`.
- La taille des médias respecte enfin le réglage `DIGIQUALI_<ELEMENT>_USE_LARGE_MEDIA_IN_GALLERY` (auparavant ignoré → toujours `medium`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)