### PR TITLE
#2334 [Control] fix: use current user as controller for new control from public interface

### DIFF
--- a/lib/digiquali_control.lib.php
+++ b/lib/digiquali_control.lib.php
@@ -287,7 +287,7 @@ function get_control_infos(CommonObject $linkedObject): array
                 }
             }
 
-            $moreParams = '&fromtype=' . $linkedObject->element . '&fromid=' . $linkedObject->id . '&fk_sheet=' . $lastControl->fk_sheet . '&fk_user_controller=' . $lastControl->fk_user_controller . (!empty($lastControl->projectid) ? '&projectid=' . $lastControl->projectid : '') . $arraySelected;
+            $moreParams = '&fromtype=' . $linkedObject->element . '&fromid=' . $linkedObject->id . '&fk_sheet=' . $lastControl->fk_sheet . (!empty($lastControl->projectid) ? '&projectid=' . $lastControl->projectid : '') . $arraySelected;
             $out['nextControl']['create_button'] = '<a class="wpeo-button button-square-60 button-radius-1 button-primary button-flex" href="' . dol_buildpath('custom/digiquali/view/control/control_card.php?action=create' . $moreParams, 1) . '" target="_blank"><i class="button-icon fas fa-plus"></i></a>';
         }
         $verdictControlColor           = $lastControl->verdict == 1 ? 'green' : 'red';


### PR DESCRIPTION
## Closes #2334

### Problème
Lors de l'ajout d'un nouveau contrôle depuis l'interface publique (bouton « + » de l'historique des contrôles), le champ contrôleur était systématiquement pré-rempli avec **l'ancien contrôleur** (celui du contrôle précédent) au lieu de l'utilisateur courant.

### Cause
Dans `get_control_infos()` (`lib/digiquali_control.lib.php`, L290), l'URL du bouton « + » ajoutait `&fk_user_controller=` avec `$lastControl->fk_user_controller`. Or `control_card.php:459` définit déjà le défaut du champ à `$user->id` — mais le paramètre d'URL (lu via `GETPOST`) écrasait ce défaut.

### Correctif
Suppression du paramètre `&fk_user_controller=...` de l'URL. Le défaut de `control_card.php` (`$user->id`) s'applique alors. La carte de contrôle s'ouvrant dans le back-office authentifié (`target="_blank"`), `$user->id` correspond bien à l'utilisateur réellement connecté qui crée le contrôle — plus robuste que de propager un `$user->id` potentiellement vide depuis la page publique.

`fk_sheet` reste transmis, donc la condition `$fkSheet > 0` reste vraie et le défaut s'active correctement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)