### PR TITLE
#2311 [Control] fix: register controllist hook context to enable list sorting & columns

### DIFF
--- a/core/modules/modDigiQuali.class.php
+++ b/core/modules/modDigiQuali.class.php
@@ -122,6 +122,7 @@ class modDigiQuali extends DolibarrModules
 				'categoryindex',
 				'mainloginpage',
                 'controlcard',
+                'controllist',
                 'publiccontrol',
                 'publicsurvey',
                 'digiqualiadmindocuments',


### PR DESCRIPTION
## Closes #2311

### Symptôme
Le tri sur la colonne « Jours avant prochain contrôle » de la liste des contrôles ne fonctionne pas (« Erreur tri non codé »).

### Cause racine
`view/control/control_list.php` construit ses colonnes personnalisées et son tri via les hooks de `ActionsDigiquali` conditionnés au contexte `controllist`. Or **ce contexte n'était pas enregistré** dans `module_parts['hooks']` (`modDigiQuali.class.php`).

Conséquence : `ActionsDigiquali` n'est jamais chargé pour cette liste (seuls `ActionsSaturne` et `ActionsReedcrm` le sont), donc **aucun** hook `controllist` ne s'exécute — en particulier `printFieldListSelect`, qui ajoute au SELECT :

```sql
, DATEDIFF(t.next_control_date, CURDATE()) AS days_remaining_before_next_control
```

Sans cet alias, le tri génère `ORDER BY days_remaining_before_next_control` sur une **colonne inexistante** → tri cassé. Les autres hooks `controllist` (rendu des cellules verdict / jours / questions, filtres de recherche) étaient également dormants.

### Diagnostic vérifié
- Classes chargées pour le contexte `controllist` : `["ActionsSaturne","ActionsReedcrm"]` → `ActionsDigiquali` absent.
- `printFieldListSelect` → chaîne vide (DATEDIFF non ajouté).
- Après enregistrement de `controllist` : `ActionsDigiquali` chargé, `printFieldListSelect` renvoie bien le `DATEDIFF`, et la requête `... ORDER BY days_remaining_before_next_control ASC` s'exécute sans erreur avec un ordre identique à `next_control_date`.

### Correctif
Ajout du contexte `controllist` à la liste des hooks du module. Trier sur le nombre de jours restants équivaut à trier sur `next_control_date` (`now` constant), ce que produit le `DATEDIFF` déjà prévu dans `ActionsDigiquali::printFieldListSelect()`.

### Note de déploiement
Les contextes de hooks sont stockés en base à l'activation (`MAIN_MODULE_DIGIQUALI_HOOKS`). La prise en compte se fait donc à la **montée de version / réactivation** du module.

### Observation connexe (hors périmètre)
Les contextes `surveylist` et `surveycard` semblent absents eux aussi des hooks enregistrés, alors que `ActionsDigiquali` les gère (`/surveylist|controllist/`). À vérifier / traiter séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)