### PR TITLE
[PublicControl] add: printPublicControlLinkedObjectIdentity hook on public control card

### DIFF
--- a/core/tpl/frontend/control_item_frontend_view.tpl.php
+++ b/core/tpl/frontend/control_item_frontend_view.tpl.php
@@ -34,8 +34,15 @@ $controlInfoArray = get_control_infos($linkedObject); ?>
         <div class="card has-margin">
             <div class="card-thumbnail"><?php echo $controlInfo['image']; ?></div>
             <div class="card-container">
-                <div class="information-type"><?php echo $linkedObjectInfoArray['linkedObject']['title']; ?></div>
-                <div class="information-label size-l"><?php echo $linkedObjectInfoArray['linkedObject']['name_field']; ?></div>
+                <?php
+                $parameters = ['linkedObjectInfoArray' => $linkedObjectInfoArray, 'linkableElements' => $linkableElements];
+                $resHook    = $hookmanager->executeHooks('printPublicControlLinkedObjectIdentity', $parameters, $linkedObject);
+                if ($resHook > 0) {
+                    print $hookmanager->resPrint;
+                } else { ?>
+                    <div class="information-type"><?php echo $linkedObjectInfoArray['linkedObject']['title']; ?></div>
+                    <div class="information-label size-l"><?php echo $linkedObjectInfoArray['linkedObject']['name_field']; ?></div>
+                <?php } ?>
                 <div class="wpeo-grid grid-no-margin">
                     <div>
                         <div class="information-type"><?php echo $controlInfo['title']; ?></div>

--- a/core/tpl/frontend/linked_object_and_control_frontend_view.tpl.php
+++ b/core/tpl/frontend/linked_object_and_control_frontend_view.tpl.php
@@ -33,8 +33,15 @@ $controlInfoArray      = get_control_infos($linkedObject); ?>
     <div class="header-information">
         <div class="information-thumbnail"><?php echo $linkedObjectInfoArray['images']; ?></div>
         <div>
-            <div class="information-type"><?php echo $linkedObjectInfoArray['linkedObject']['title']; ?></div>
-            <div class="information-label size-l"><?php echo $linkedObjectInfoArray['linkedObject']['name_field']; ?></div>
+            <?php
+            $parameters = ['linkedObjectInfoArray' => $linkedObjectInfoArray, 'linkableElements' => $linkableElements];
+            $resHook    = $hookmanager->executeHooks('printPublicControlLinkedObjectIdentity', $parameters, $linkedObject);
+            if ($resHook > 0) {
+                print $hookmanager->resPrint;
+            } else { ?>
+                <div class="information-type"><?php echo $linkedObjectInfoArray['linkedObject']['title']; ?></div>
+                <div class="information-label size-l"><?php echo $linkedObjectInfoArray['linkedObject']['name_field']; ?></div>
+            <?php } ?>
             <div class="information-label objet-label"><?php echo $linkedObjectInfoArray['linkedObject']['qc_frequency']; ?></div>
             <div class="information-type"><?php echo $linkedObjectInfoArray['parentLinkedObject']['title']; ?></div>
             <div class="information-label"><?php echo $linkedObjectInfoArray['parentLinkedObject']['name_field']; ?></div>


### PR DESCRIPTION
## Changements
- Ajout d'un point de hook `printPublicControlLinkedObjectIdentity` dans l'interface publique d'historique de contrôle, sur les deux cartes (« objet lié & contrôle » et « liste des contrôles »).
- Ce hook permet à un module tiers de remplacer le bloc d'identité de l'objet lié (libellé + valeur principale) affiché sur la carte.
- Rétro-compatible : si aucun module ne répond (`resHook <= 0`), l'affichage par défaut (`name_field`) est conservé à l'identique. Aucun changement de comportement pour une installation DigiQuali seule.

## Fichiers modifiés
- core/tpl/frontend/control_item_frontend_view.tpl.php
- core/tpl/frontend/linked_object_and_control_frontend_view.tpl.php

## Contexte
Point d'extension nécessaire pour Evarisk/dolicar#442 : affichage de la plaque d'immatriculation du véhicule en évidence sur la carte de contrôle public. L'implémentation se fait côté dolicar via ce hook.
