### PR TITLE
#2446 [ControlDocument] fix: rename pdf model label to a readable name (FR + EN)

### DIFF
--- a/core/modules/digiquali/digiqualidocuments/controldocument/pdf_controldocument.modules.php
+++ b/core/modules/digiquali/digiqualidocuments/controldocument/pdf_controldocument.modules.php
@@ -106,7 +106,7 @@ class pdf_controldocument extends SaturneDocumentModel
 
         parent::__construct($db, $this->module, $this->document_type);
 
-        $this->name        = 'controldocument';
+        $this->name        = $langs->trans('ControlDocumentPDF');
         $this->description = $langs->trans('ControlDocumentPDFDescription');
         $this->type        = 'pdf';
         $this->height      = 10;

--- a/langs/en_US/digiquali.lang
+++ b/langs/en_US/digiquali.lang
@@ -1,0 +1,20 @@
+# Copyright (C) 2022-2023 EVARISK <technique@evarisk.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#
+# ControlDocument
+#
+
+ControlDocumentPDF                      = Control Sheet PDF with photo

--- a/langs/en_US/index.php
+++ b/langs/en_US/index.php
@@ -1,0 +1,2 @@
+<?php
+//Silence is golden

--- a/langs/fr_FR/digiquali.lang
+++ b/langs/fr_FR/digiquali.lang
@@ -482,7 +482,7 @@ NoObjectLineAnswersPhoto                = Pas de photos sur les réponses du %s
 # Data - Donnée
 ControlDocument                         = Fiche de Contrôle
 Controldocument                         = Fiche de Contrôle
-ControlDocumentPDF                      = FC-A4-MEDIA-PDF
+ControlDocumentPDF                      = Fiche de Contrôle PDF avec photo
 ControlDocumentsMin                     = fiches de contôle
 ControlDocumentDisplayMedias            = Afficher les médias dans la fiche de contrôle
 ControlDocumentDisplayMediasDescription = Afficher les médias des questions dans la fiche de contrôle ODT


### PR DESCRIPTION
## Changements

- `ControlDocumentPDF` (fr_FR) : `FC-A4-MEDIA-PDF` → **« Fiche de Contrôle PDF avec photo »**
- Ajout de la traduction **en_US** : « Control Sheet PDF with photo » (+ `langs/en_US/index.php`)
- `pdf_controldocument::__construct` : `$this->name = $langs->trans('ControlDocumentPDF')` au lieu de l'identifiant brut `'controldocument'`

## Pourquoi

Le libellé du modèle PDF de contrôle était incohérent selon le contexte : `FC-A4-MEDIA-PDF` via l'init du module, mais « fiche de controle » (traduction de l'identifiant brut `controldocument`) quand il était réactivé via le switch admin. En basant `$this->name` sur la clé de langue, la liste admin, le sélecteur de génération et le pied de page du PDF affichent désormais tous le même libellé.

## Fichiers modifiés

- `langs/fr_FR/digiquali.lang`
- `langs/en_US/digiquali.lang` (nouveau)
- `langs/en_US/index.php` (nouveau)
- `core/modules/digiquali/digiqualidocuments/controldocument/pdf_controldocument.modules.php`

## Note

Les lignes `llx_document_model` déjà enregistrées conservent l'ancien libellé jusqu'à la réactivation du modèle (le `libelle` n'est réécrit qu'à ce moment).

## Issue

#2446
