### PR TITLE
#2442 [Control] fix: search control list by signatory (controller) name

### DIFF
--- a/class/actions_digiquali.class.php
+++ b/class/actions_digiquali.class.php
@@ -378,7 +378,7 @@ class ActionsDigiquali
      * @return int                   0 < on error, 0 on success, 1 to replace standard code
      * @throws Exception
      */
-    public function printFieldListSearch(array $parameters): int
+    public function printFieldListSearch(array $parameters, $object = null): int
     {
         global $conf;
 
@@ -406,6 +406,26 @@ class ActionsDigiquali
                 }
                 if ($parameters['val'] === '-1') {
                     return 1; // or return 1 to replace standard code
+                }
+            }
+
+            // Signatory role columns (e.g. Controller) have no real t.<role> column: filter by
+            // the signatory's name (linked user or contact) through the signature table.
+            $signatoriesInDictionary = $conf->cache['signatoriesInDictionary'] ?? [];
+            if (is_object($object) && is_array($signatoriesInDictionary) && !empty($signatoriesInDictionary)) {
+                foreach ($signatoriesInDictionary as $signatoryInDictionary) {
+                    if ($parameters['key'] === $signatoryInDictionary->ref && trim((string) $parameters['val']) !== '') {
+                        $nameFilter = natural_search(['su.firstname', 'su.lastname', 'sc.firstname', 'sc.lastname'], $parameters['val'], 0, 1);
+                        $sql  = ' AND EXISTS (SELECT 1 FROM ' . $this->db->prefix() . 'saturne_object_signature AS sgn';
+                        $sql .= ' LEFT JOIN ' . $this->db->prefix() . 'user AS su ON (sgn.element_type = \'user\' AND sgn.element_id = su.rowid)';
+                        $sql .= ' LEFT JOIN ' . $this->db->prefix() . 'socpeople AS sc ON (sgn.element_type = \'socpeople\' AND sgn.element_id = sc.rowid)';
+                        $sql .= ' WHERE sgn.fk_object = t.rowid';
+                        $sql .= ' AND sgn.object_type = \'' . $this->db->escape($object->element) . '\'';
+                        $sql .= ' AND sgn.role = \'' . $this->db->escape($signatoryInDictionary->ref) . '\'';
+                        $sql .= ' AND ' . $nameFilter . ')';
+                        $this->resprints = $sql;
+                        return 1; // or return 1 to replace standard code
+                    }
                 }
             }
         }

--- a/view/control/control_list.php
+++ b/view/control/control_list.php
@@ -130,7 +130,10 @@ $conf->cache['signatoriesInDictionary'] = $signatoriesInDictionary;
 if (is_array($signatoriesInDictionary) && !empty($signatoriesInDictionary)) {
     $customFieldsPosition = 111;
     foreach ($signatoriesInDictionary as $signatoryInDictionary) {
-        $object->fields[$signatoryInDictionary->ref] = ['label' => $signatoryInDictionary->ref, 'enabled' => 1, 'position' => $customFieldsPosition++, 'visible' => 2, 'css' => 'minwidth300 maxwidth500 widthcentpercentminusxx right'];
+        // Signatory role columns are computed from the signatures (no real t.<ref> column in
+        // the control table), so they cannot be ordered as a base-table column (disablesort).
+        // Search IS supported: printFieldListSearch() filters on the signatory's name.
+        $object->fields[$signatoryInDictionary->ref] = ['label' => $signatoryInDictionary->ref, 'enabled' => 1, 'position' => $customFieldsPosition++, 'visible' => 2, 'css' => 'minwidth300 maxwidth500 widthcentpercentminusxx right', 'disablesort' => 1];
         $excludeFields[]                             = $signatoryInDictionary->ref;
     }
 }


### PR DESCRIPTION
## Contexte

Sur la liste des contrôles, rechercher dans la colonne d'un rôle signataire (« Controller », etc.) provoquait une erreur SQL `Unknown column 't.Controller'` : ces colonnes sont calculées depuis les signatures, il n'existe pas de colonne réelle `t.<role>` dans la table de contrôle.

## Changements

- **Recherche réelle par signataire** (`printFieldListSearch`) : quand on cherche dans une colonne de rôle signataire, on filtre sur le **nom du signataire** (user ou contact) via une sous-requête `EXISTS` sur `saturne_object_signature` jointe à `user`/`socpeople`. Fonctionne pour tous les rôles et pour les listes control + survey (`object_type = $object->element`).
- **Colonne signataire** (`control_list.php`) : `disablesort = 1` (impossible d'ordonner par une colonne virtuelle de signature). La recherche reste active et fonctionnelle.

> Le filet de sécurité générique côté Saturne (ne pas générer `t.<colonne_virtuelle>` pour les champs de `$excludeFields`) fait l'objet d'une PR Saturne séparée.

## Fichiers modifiés

- `class/actions_digiquali.class.php`
- `view/control/control_list.php`

## Issue

#2442
