### PR TITLE
#2451 [Control] fix: guard getNomUrl for linked objects without it

### DIFF
--- a/lib/digiquali_control.lib.php
+++ b/lib/digiquali_control.lib.php
@@ -84,7 +84,7 @@ function get_linked_object_infos(CommonObject $linkedObject, array $linkableElem
 
     $permissionToRead = $user->hasRight('produit', 'lire');
 
-    $linkableElement = $linkableElements[$linkedObject->element];
+    $linkableElement = $linkableElements[$linkedObject->element] ?? [];
 
     // TODO: see if we can remove this if
     $modulePart = $linkedObject->element;
@@ -112,8 +112,15 @@ function get_linked_object_infos(CommonObject $linkedObject, array $linkableElem
 
     $out['linkedObject']['links'] = [];
     $out['linkedObject']['files'] = $filteredEcmFilesLine;
-    $out['linkedObject']['title']      = $langs->transnoentities($linkableElement['langs']);
-    $out['linkedObject']['name_field'] = $linkedObject->getNomUrl(1, !$permissionToRead ? 'nolink' : '');
+    $out['linkedObject']['title']      = $langs->transnoentities(!empty($linkableElement['langs']) ? $linkableElement['langs'] : dol_ucfirst($linkedObject->element));
+    if (method_exists($linkedObject, 'getNomUrl')) {
+        $out['linkedObject']['name_field'] = $linkedObject->getNomUrl(1, !$permissionToRead ? 'nolink' : '');
+    } else {
+        // Some linked objects (e.g. productbatch) don't implement getNomUrl(): fall back to picto + name
+        $picto = !empty($linkableElement['picto']) ? img_picto('', $linkableElement['picto'], 'class="pictofixedwidth"') : '';
+        $name  = !empty($linkedObject->ref) ? $linkedObject->ref : (!empty($linkedObject->label) ? $linkedObject->label : ($linkedObject->batch ?? ''));
+        $out['linkedObject']['name_field'] = $picto . dol_escape_htmltag($name);
+    }
 
     // Per-element label and description field mapping
     $elementFieldsMap = [


### PR DESCRIPTION
## Changements

Corrige l'erreur fatale `Call to undefined method 'getNomUrl'` sur l'interface publique quand le contrôle est lié à un objet de type `productbatch` (instance `Productbatch`, qui n'implémente pas `getNomUrl()` et n'est pas présent dans les métadonnées `saturne_get_objects_metadata()`).

Dans `get_linked_object_infos()` :

- `$linkableElement` sécurisé avec `?? []` (le type `productbatch` n'est pas dans les métadonnées) ;
- appel à `getNomUrl()` protégé par `method_exists()` ;
- repli sur `picto + nom` (ref → label → batch) lorsque la méthode est absente, comme le rendu d'avant #2407.

Correctif centralisé : la fonction alimente les vues publiques (en-tête de réponse, liste de contrôles, documentation), un seul point corrigé couvre les trois.

## Fichiers modifiés

- `lib/digiquali_control.lib.php`

## Issue

Fixes #2451
