### PR TITLE
#2455 [Sheet] Ajout des options de creation du controle (projet, tags, visibilite)

### DIFF
--- a/class/sheet.class.php
+++ b/class/sheet.class.php
@@ -124,6 +124,9 @@ class Sheet extends SaturneObject
         'photo'               => ['type' => 'text',         'label' => 'Photo',              'enabled' => 1, 'position' => 95,  'notnull' => 0, 'visible' => -2, 'disablesearch' => 1, 'disablesort' => 1],
         'success_rate'        => ['type' => 'real',         'label' => 'SuccessScore',       'enabled' => 1, 'position' => 35,  'notnull' => 0, 'visible' => 2, 'help' => 'PercentageValue'],
         'mandatory_questions' => ['type' => 'text',         'label' => 'MandatoryQuestions', 'enabled' => 1, 'position' => 100, 'notnull' => 1, 'visible' => 0],
+        'show_project'        => ['type' => 'boolean',      'label' => 'ShowProjectOnControl', 'enabled' => 1, 'position' => 101, 'notnull' => 0, 'visible' => 0, 'default' => 1],
+        'show_tags'           => ['type' => 'boolean',      'label' => 'ShowTagsOnControl',    'enabled' => 1, 'position' => 102, 'notnull' => 0, 'visible' => 0, 'default' => 1],
+        'default_control_tags' => ['type' => 'text',        'label' => 'DefaultControlTags',   'enabled' => 1, 'position' => 103, 'notnull' => 0, 'visible' => 0],
         'fk_user_creat'       => ['type' => 'integer:User:user/class/user.class.php', 'label' => 'UserAuthor', 'picto' => 'user', 'enabled' => 1, 'position' => 110, 'notnull' => 1, 'visible' => -2, 'foreignkey' => 'user.rowid'],
         'fk_user_modif'       => ['type' => 'integer:User:user/class/user.class.php', 'label' => 'UserModif',  'picto' => 'user', 'enabled' => 1, 'position' => 120, 'notnull' => 0, 'visible' => -2, 'foreignkey' => 'user.rowid']
     ];
@@ -207,6 +210,21 @@ class Sheet extends SaturneObject
      * @var string Mandatory questions.
      */
     public ?string $mandatory_questions = '{}';
+
+    /**
+     * @var int|null Show project on control creation.
+     */
+    public ?int $show_project = 1;
+
+    /**
+     * @var int|null Show tags on control creation.
+     */
+    public ?int $show_tags = 1;
+
+    /**
+     * @var string|null Default control tags JSON.
+     */
+    public ?string $default_control_tags;
 
     /**
      * @var int User ID.

--- a/langs/fr_FR/digiquali.lang
+++ b/langs/fr_FR/digiquali.lang
@@ -40,6 +40,15 @@ GenerateMainSheetCategories    = Génération des catégories principales du mod
 MainSheetCategoriesDescription = Cette option permet la génération des catégories principales du modèle de contrôle. <br> Les catégories créées seront : <ul><li>Contrôle</li><ul><li>Qualité</li><ul><li>Hygiène et Sécurité</li><ul><li>Trousses de premier secours</li></ul></ul><li>Matériels</li><ul><li>Masque</li></ul><li>Véhicules</li><ul><li>Voiture</li><li>Véhicule industriel</li></ul></ul></ul>
 SheetMainCategory              = Choix de la catégorie principale du modèle de contrôle
 SheetMainCategoryDescription   = Cette option permet de choisir quelle catégorie sera utilisée lors du choix de catégorie pendant la création d'un contrôle
+ShowProjectOnControl           = Afficher le projet sur le contrôle
+ShowTagsOnControl              = Afficher les tags sur le contrôle
+DefaultControlTags             = Tags par défaut du contrôle
+ControlCreationOptions         = Options de création du contrôle
+ShowProjectOnControlHelp       = Si activé, le champ projet sera visible lors de la création d'un contrôle depuis ce modèle
+ShowTagsOnControlHelp          = Si activé, le champ tags/catégories sera visible lors de la création d'un contrôle depuis ce modèle
+DefaultControlTagsHelp         = Catégories qui seront pré-sélectionnées lors de la création d'un contrôle depuis ce modèle
+DefaultControlProject          = Projet par défaut du contrôle
+ControlledObjectsTitle         = Objets contrôlés par ce Contrôle/Questionnaire
 
 # Control - Contrôle
 DisplayMediasSample                                = Afficher les médias d'exemple des questions

--- a/sql/sheet/llx_digiquali_sheet.sql
+++ b/sql/sheet/llx_digiquali_sheet.sql
@@ -30,6 +30,9 @@ CREATE TABLE llx_digiquali_sheet(
   photo               text,
   success_rate        double(24,8),
   mandatory_questions text,
+  show_project        smallint DEFAULT 1,
+  show_tags           smallint DEFAULT 1,
+  default_control_tags text,
   fk_user_creat       integer NOT NULL,
   fk_user_modif       integer
 ) ENGINE=innodb;

--- a/sql/update.sql
+++ b/sql/update.sql
@@ -163,3 +163,8 @@ INSERT INTO llx_c_question_type (rowid, entity, ref, label, description, active,
 -- 23.1.0
 ALTER TABLE llx_digiquali_riskassessment ADD fk_parent integer DEFAULT 0 NOT NULL AFTER fk_activity;
 UPDATE llx_digiquali_riskassessment SET fk_parent = 0 WHERE fk_parent IS NULL;
+
+-- 23.2.0
+ALTER TABLE llx_digiquali_sheet ADD COLUMN show_project SMALLINT DEFAULT 1;
+ALTER TABLE llx_digiquali_sheet ADD COLUMN show_tags SMALLINT DEFAULT 1;
+ALTER TABLE llx_digiquali_sheet ADD COLUMN default_control_tags TEXT;

--- a/view/control/control_card.php
+++ b/view/control/control_card.php
@@ -459,11 +459,16 @@ if ($action == 'create') {
         $object->fields['fk_user_controller']['visible'] = 1;
         $object->fields['fk_user_controller']['default'] = $user->id;
         if (!empty($conf->projet->enabled)) {
-            $object->fields['projectid']['visible'] = 1;
+            if (!empty($sheet->show_project)) {
+                $object->fields['projectid']['visible'] = 1;
+            }
             if (!empty($sheet->fk_project)) {
                 $_POST['projectid'] = $sheet->fk_project;
             }
         }
+        // Store show_project to handle hidden input after commonfields
+        $sheetShowProject = $sheet->show_project;
+        $sheetDefaultProjectId = $sheet->fk_project;
     }
 
     if ($viewmode == 'images') {
@@ -537,16 +542,32 @@ if ($action == 'create') {
     // Common attributes
     require_once DOL_DOCUMENT_ROOT . '/core/tpl/commonfields_add.tpl.php';
 
+    // Hidden project input when project field is not visible but sheet has a default project
+    if ($fkSheet > 0 && empty($sheetShowProject) && !empty($sheetDefaultProjectId)) {
+        print '<input type="hidden" name="projectid" value="' . intval($sheetDefaultProjectId) . '">';
+    }
+
     if ($fkSheet > 0) {
+        // Default control tags from sheet
+        $defaultControlTags = json_decode($sheet->default_control_tags ?? '[]', true) ?: [];
+        $selectedCategories = GETPOSTISSET('categories') ? GETPOST('categories', 'array') : $defaultControlTags;
+
         // Categories
         if (!empty($conf->categorie->enabled)) {
-            print '<tr><td>' . ($source != 'pwa' ? $langs->trans('Categories') : img_picto('', 'fontawesome_fa-tags_fas_#000000_2em', 'class="pictofixedwidth"')) . '</td><td>';
-            $categoryArborescence = $form->select_all_categories('control', '', 'parent', 64, 0, 1);
-            print ($source != 'pwa' ? img_picto('', 'category', 'class="pictofixedwidth"') : '') . $form::multiselectarray('categories', $categoryArborescence, GETPOST('categories', 'array'), '', 0, 'minwidth100imp maxwidth500 widthcentpercentminusxx');
-            if ($source != 'pwa') {
-                print '<a class="butActionNew" href="' . DOL_URL_ROOT . '/categories/index.php?type=control&backtopage=' . urlencode($_SERVER['PHP_SELF'] . '?action=create') . '" target="_blank"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans('AddCategories') . '"></span></a>';
+            if (!empty($sheet->show_tags)) {
+                print '<tr><td>' . ($source != 'pwa' ? $langs->trans('Categories') : img_picto('', 'fontawesome_fa-tags_fas_#000000_2em', 'class="pictofixedwidth"')) . '</td><td>';
+                $categoryArborescence = $form->select_all_categories('control', '', 'parent', 64, 0, 1);
+                print ($source != 'pwa' ? img_picto('', 'category', 'class="pictofixedwidth"') : '') . $form::multiselectarray('categories', $categoryArborescence, $selectedCategories, '', 0, 'minwidth100imp maxwidth500 widthcentpercentminusxx');
+                if ($source != 'pwa') {
+                    print '<a class="butActionNew" href="' . DOL_URL_ROOT . '/categories/index.php?type=control&backtopage=' . urlencode($_SERVER['PHP_SELF'] . '?action=create') . '" target="_blank"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans('AddCategories') . '"></span></a>';
+                }
+                print '</td></tr>';
+            } else {
+                // Hidden inputs to still apply default tags
+                foreach ($selectedCategories as $catId) {
+                    print '<input type="hidden" name="categories[]" value="' . intval($catId) . '">';
+                }
             }
-            print '</td></tr>';
         }
 
         // Other attributes

--- a/view/sheet/sheet_card.php
+++ b/view/sheet/sheet_card.php
@@ -241,6 +241,10 @@ if (empty($reshook)) {
 		}
 		$object->element_linked = json_encode($showArray);
 
+		$object->default_control_tags = json_encode(GETPOST('default_control_tags', 'array'));
+		$_POST['show_project'] = GETPOST('ctrl_show_project');
+		$_POST['show_tags'] = GETPOST('ctrl_show_tags');
+
 		if (empty(GETPOST('categories', 'array'))) {
 			$category->fetch($conf->global->DIGIQUALI_SHEET_DEFAULT_TAG);
 			$defaultCategory[] = $category->id;
@@ -256,6 +260,10 @@ if (empty($reshook)) {
 			}
 		}
 		$object->element_linked = json_encode($showArray);
+
+		$object->default_control_tags = json_encode(GETPOST('default_control_tags', 'array'));
+		$_POST['show_project'] = GETPOST('ctrl_show_project');
+		$_POST['show_tags'] = GETPOST('ctrl_show_tags');
 
 		if (empty(GETPOST('categories', 'array'))) {
 			$category->fetch($conf->global->DIGIQUALI_SHEET_DEFAULT_TAG);
@@ -498,14 +506,46 @@ if ($action == 'create') {
     print $form::selectarray('type', $object->fields['type']['arrayofkeyval'], GETPOST('type'));
     print '</td></tr>';
 
-    // Project
-    if (!empty($conf->projet->enabled)) {
-        print '<tr><td class="">' . img_picto('', 'project', 'class="paddingrightonly"') . $langs->trans('Project') . '</td><td>';
-        print $formproject->select_projects(-1, GETPOSTINT('fk_project'), 'fk_project', 0, 0, 1, 0, 0, 0, 0, '', 1, 0, 'maxwidth500');
-        print '</td></tr>';
-    }
+	// Control creation options
+	print '<tr class="liste_titre"><td colspan="2">' . $langs->trans('ControlCreationOptions') . '</td></tr>';
 
-    //FK Element
+	// Show project on control
+	if (!empty($conf->projet->enabled)) {
+		print '<tr><td>' . $langs->trans('ShowProjectOnControl') . ' ' . img_picto($langs->trans('ShowProjectOnControlHelp'), 'help') . '</td><td>';
+		print $form::selectarray('ctrl_show_project', [0 => $langs->trans('No'), 1 => $langs->trans('Yes')], GETPOSTISSET('ctrl_show_project') ? GETPOST('ctrl_show_project') : 1);
+		print '</td></tr>';
+
+		// Default project for control
+		print '<tr><td>' . img_picto('', 'project', 'class="paddingrightonly"') . $langs->trans('DefaultControlProject') . '</td><td>';
+		print $formproject->select_projects(-1, GETPOSTINT('fk_project'), 'fk_project', 0, 0, 1, 0, 0, 0, 0, '', 1, 0, 'maxwidth500');
+		print '</td></tr>';
+	}
+
+	// Default control tags
+	if (!empty($conf->categorie->enabled)) {
+		print '<tr><td>' . $langs->trans('DefaultControlTags') . ' ' . img_picto($langs->trans('DefaultControlTagsHelp'), 'help') . '</td><td>';
+		$controlCateArbo = $form->select_all_categories('control', '', 'parent', 64, 0, 1);
+		print img_picto('', 'category', 'class="pictofixedwidth"') . $form::multiselectarray('default_control_tags', $controlCateArbo, GETPOST('default_control_tags', 'array'), '', 0, 'minwidth100imp maxwidth500 widthcentpercentminusxx');
+		print '</td></tr>';
+
+		// Show tags on control
+		print '<tr><td>' . $langs->trans('ShowTagsOnControl') . ' ' . img_picto($langs->trans('ShowTagsOnControlHelp'), 'help') . '</td><td>';
+		print $form::selectarray('ctrl_show_tags', [0 => $langs->trans('No'), 1 => $langs->trans('Yes')], GETPOSTISSET('ctrl_show_tags') ? GETPOST('ctrl_show_tags') : 1);
+		print '</td></tr>';
+	}
+
+	if (!empty($conf->categorie->enabled)) {
+		// Categories
+		print '<tr><td class="fieldrequired">'.$langs->trans("Categories").'</td><td>';
+		$cate_arbo = $form->select_all_categories('sheet', '', 'parent', 64, 0, 1);
+		print img_picto('', 'category', 'class="pictofixedwidth"').$form::multiselectarray('categories', $cate_arbo, GETPOST('categories', 'array'), '', 0, 'minwidth100imp maxwidth500 widthcentpercentminusxx');
+        print '<a class="butActionNew" href="' . DOL_URL_ROOT . '/categories/index.php?type=sheet&backtopage=' . urlencode($_SERVER['PHP_SELF'] . '?action=create') . '" target="_blank"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans('AddCategories') . '"></span></a>';
+		print "</td></tr>";
+	}
+
+    // Linked elements
+    print '<tr class="liste_titre"><td colspan="2"><b>' . $langs->trans('ControlledObjectsTitle') . '</b></td></tr>';
+
     $nbLinkableElements = 0;
     foreach ($objectsMetadata as $objectType => $objectMetadata) {
         if ($objectMetadata['conf'] == 0) {
@@ -528,14 +568,7 @@ if ($action == 'create') {
         print saturne_show_notice($langs->transnoentities('MissingConfigElementTypeTitle'), $noticeMessage, 'error', 'notice-infos', true);
     }
 
-	if (!empty($conf->categorie->enabled)) {
-		// Categories
-		print '<tr><td>'.$langs->trans("Categories").'</td><td>';
-		$cate_arbo = $form->select_all_categories('sheet', '', 'parent', 64, 0, 1);
-		print img_picto('', 'category', 'class="pictofixedwidth"').$form::multiselectarray('categories', $cate_arbo, GETPOST('categories', 'array'), '', 0, 'minwidth100imp maxwidth500 widthcentpercentminusxx');
-        print '<a class="butActionNew" href="' . DOL_URL_ROOT . '/categories/index.php?type=sheet&backtopage=' . urlencode($_SERVER['PHP_SELF'] . '?action=create') . '" target="_blank"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans('AddCategories') . '"></span></a>';
-		print "</td></tr>";
-	}
+
 
 	// Other attributes
 	include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_add.tpl.php';
@@ -590,14 +623,55 @@ if (($id || $ref) && $action == 'edit') {
     print $form::selectarray('type', $object->fields['type']['arrayofkeyval'], $object->type);
     print '</td></tr>';
 
-    // Project
-    if (!empty($conf->projet->enabled)) {
-        print '<tr><td class="">' . img_picto('', 'project', 'class="paddingrightonly"') . $langs->trans('Project') . '</td><td>';
-        print $formproject->select_projects(-1, $object->fk_project, 'fk_project', 0, 0, 1, 0, 0, 0, 0, '', 1, 0, 'maxwidth500');
-        print '</td></tr>';
-    }
+	// Control creation options
+	print '<tr class="liste_titre"><td colspan="2">' . $langs->trans('ControlCreationOptions') . '</td></tr>';
 
-    //FK Element
+	// Show project on control
+	if (!empty($conf->projet->enabled)) {
+		print '<tr><td>' . $langs->trans('ShowProjectOnControl') . ' ' . img_picto($langs->trans('ShowProjectOnControlHelp'), 'help') . '</td><td>';
+		print $form::selectarray('ctrl_show_project', [0 => $langs->trans('No'), 1 => $langs->trans('Yes')], GETPOSTISSET('ctrl_show_project') ? GETPOST('ctrl_show_project') : $object->show_project);
+		print '</td></tr>';
+
+		// Default project for control
+		print '<tr><td>' . img_picto('', 'project', 'class="paddingrightonly"') . $langs->trans('DefaultControlProject') . '</td><td>';
+		print $formproject->select_projects(-1, $object->fk_project, 'fk_project', 0, 0, 1, 0, 0, 0, 0, '', 1, 0, 'maxwidth500');
+		print '</td></tr>';
+	}
+
+	// Default control tags
+	if (!empty($conf->categorie->enabled)) {
+		print '<tr><td>' . $langs->trans('DefaultControlTags') . ' ' . img_picto($langs->trans('DefaultControlTagsHelp'), 'help') . '</td><td>';
+		$controlCateArbo = $form->select_all_categories('control', '', 'parent', 64, 0, 1);
+		$defaultControlTagsSelected = GETPOSTISSET('default_control_tags') ? GETPOST('default_control_tags', 'array') : (json_decode($object->default_control_tags ?? '[]', true) ?: []);
+		print img_picto('', 'category', 'class="pictofixedwidth"') . $form::multiselectarray('default_control_tags', $controlCateArbo, $defaultControlTagsSelected, '', 0, 'minwidth100imp maxwidth500 widthcentpercentminusxx');
+		print '</td></tr>';
+
+		// Show tags on control
+		print '<tr><td>' . $langs->trans('ShowTagsOnControl') . ' ' . img_picto($langs->trans('ShowTagsOnControlHelp'), 'help') . '</td><td>';
+		print $form::selectarray('ctrl_show_tags', [0 => $langs->trans('No'), 1 => $langs->trans('Yes')], GETPOSTISSET('ctrl_show_tags') ? GETPOST('ctrl_show_tags') : $object->show_tags);
+		print '</td></tr>';
+	}
+
+	// Tags-Categories
+	if ($conf->categorie->enabled) {
+		print '<tr><td class="fieldrequired">'.$langs->trans("Categories").'</td><td>';
+		$cate_arbo = $form->select_all_categories('sheet', '', 'parent', 64, 0, 1);
+		$c = new Categorie($db);
+		$cats = $c->containing($object->id, 'sheet');
+		$arrayselected = array();
+		if (is_array($cats)) {
+			foreach ($cats as $cat) {
+				$arrayselected[] = $cat->id;
+			}
+		}
+		print img_picto('', 'category', 'class="pictofixedwidth"').$form::multiselectarray('categories', $cate_arbo, (GETPOSTISSET('categories') ? GETPOST('categories', 'array') : $arrayselected), '', 0, 'minwidth100imp maxwidth500 widthcentpercentminusxx');
+        print '<a class="butActionNew" href="' . DOL_URL_ROOT . '/categories/index.php?type=sheet&backtopage=' . urlencode($_SERVER['PHP_SELF'] . '?action=create') . '" target="_blank"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans('AddCategories') . '"></span></a>';
+		print "</td></tr>";
+	}
+
+    // Linked elements
+    print '<tr class="liste_titre"><td colspan="2"><b>' . $langs->trans('ControlledObjectsTitle') . '</b></td></tr>';
+
 	$elementLinked = json_decode($object->element_linked ?? '{}') ?? new stdClass();
 
 	foreach ($objectsMetadata as $key => $element) {
@@ -613,22 +687,7 @@ if (($id || $ref) && $action == 'edit') {
 		print '</td></tr>';
 	}
 
-	// Tags-Categories
-	if ($conf->categorie->enabled) {
-		print '<tr><td>'.$langs->trans("Categories").'</td><td>';
-		$cate_arbo = $form->select_all_categories('sheet', '', 'parent', 64, 0, 1);
-		$c = new Categorie($db);
-		$cats = $c->containing($object->id, 'sheet');
-		$arrayselected = array();
-		if (is_array($cats)) {
-			foreach ($cats as $cat) {
-				$arrayselected[] = $cat->id;
-			}
-		}
-		print img_picto('', 'category', 'class="pictofixedwidth"').$form::multiselectarray('categories', $cate_arbo, (GETPOSTISSET('categories') ? GETPOST('categories', 'array') : $arrayselected), '', 0, 'minwidth100imp maxwidth500 widthcentpercentminusxx');
-        print '<a class="butActionNew" href="' . DOL_URL_ROOT . '/categories/index.php?type=sheet&backtopage=' . urlencode($_SERVER['PHP_SELF'] . '?action=create') . '" target="_blank"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans('AddCategories') . '"></span></a>';
-		print "</td></tr>";
-	}
+
 
 	// Other attributes
 	include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_edit.tpl.php';
@@ -724,6 +783,52 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 		print $form->showCategories($object->id, 'sheet', 1);
 		print "</td></tr>";
 	}
+
+	// Control creation options
+	print '<tr class="liste_titre"><td colspan="2">' . $langs->trans('ControlCreationOptions') . '</td></tr>';
+
+	// Show project on control
+	if (!empty($conf->projet->enabled)) {
+		print '<tr><td class="titlefield">' . $langs->trans('ShowProjectOnControl') . '</td><td>';
+		print yn($object->show_project);
+		print '</td></tr>';
+
+		// Default project for control
+		print '<tr><td>' . img_picto('', 'project', 'class="paddingrightonly"') . $langs->trans('DefaultControlProject') . '</td><td>';
+		if (!empty($object->fk_project)) {
+			$tmpProject = new Project($db);
+			$tmpProject->fetch($object->fk_project);
+			print $tmpProject->getNomUrl(1);
+		} else {
+			print '<span class="opacitymedium">' . $langs->trans('None') . '</span>';
+		}
+		print '</td></tr>';
+	}
+
+	// Default control tags
+	if (!empty($conf->categorie->enabled)) {
+		print '<tr><td>' . $langs->trans('DefaultControlTags') . '</td><td>';
+		$defaultControlTagIds = json_decode($object->default_control_tags ?? '[]', true) ?: [];
+		if (!empty($defaultControlTagIds)) {
+			$tmpCategory = new Categorie($db);
+			foreach ($defaultControlTagIds as $catId) {
+				if ($tmpCategory->fetch($catId) > 0) {
+					print '<span class="noborderoncategories" ' . $tmpCategory->getHtmlColor() . '>' . $tmpCategory->getNomUrl(1) . '</span> ';
+				}
+			}
+		} else {
+			print '<span class="opacitymedium">' . $langs->trans('None') . '</span>';
+		}
+		print '</td></tr>';
+
+		// Show tags on control
+		print '<tr><td>' . $langs->trans('ShowTagsOnControl') . '</td><td>';
+		print yn($object->show_tags);
+		print '</td></tr>';
+	}
+
+	// Linked elements
+	print '<tr class="liste_titre"><td colspan="2"><b>' . $langs->trans('ControlledObjectsTitle') . '</b></td></tr>';
 
 	$elementLinked = json_decode($object->element_linked ?? '{}') ?? new stdClass();
 

--- a/view/sheet/sheet_card.php
+++ b/view/sheet/sheet_card.php
@@ -506,41 +506,41 @@ if ($action == 'create') {
     print $form::selectarray('type', $object->fields['type']['arrayofkeyval'], GETPOST('type'));
     print '</td></tr>';
 
+	if (!empty($conf->categorie->enabled)) {
+		// Categories
+		print '<tr><td class="fieldrequired">' . img_picto('', 'category', 'class="paddingrightonly"') . $langs->trans("Categories").'</td><td>';
+		$cate_arbo = $form->select_all_categories('sheet', '', 'parent', 64, 0, 1);
+		print $form::multiselectarray('categories', $cate_arbo, GETPOST('categories', 'array'), '', 0, 'minwidth100imp maxwidth500 widthcentpercentminusxx');
+        print '<a class="butActionNew" href="' . DOL_URL_ROOT . '/categories/index.php?type=sheet&backtopage=' . urlencode($_SERVER['PHP_SELF'] . '?action=create') . '" target="_blank"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans('AddCategories') . '"></span></a>';
+		print "</td></tr>";
+	}
+
 	// Control creation options
-	print '<tr class="liste_titre"><td colspan="2">' . $langs->trans('ControlCreationOptions') . '</td></tr>';
+	print '<tr class="liste_titre"><td colspan="2"><b>' . $langs->trans('ControlCreationOptions') . '</b></td></tr>';
 
-	// Show project on control
+	// Default project for control
 	if (!empty($conf->projet->enabled)) {
-		print '<tr><td>' . $langs->trans('ShowProjectOnControl') . ' ' . img_picto($langs->trans('ShowProjectOnControlHelp'), 'help') . '</td><td>';
-		print $form::selectarray('ctrl_show_project', [0 => $langs->trans('No'), 1 => $langs->trans('Yes')], GETPOSTISSET('ctrl_show_project') ? GETPOST('ctrl_show_project') : 1);
-		print '</td></tr>';
-
-		// Default project for control
 		print '<tr><td>' . img_picto('', 'project', 'class="paddingrightonly"') . $langs->trans('DefaultControlProject') . '</td><td>';
 		print $formproject->select_projects(-1, GETPOSTINT('fk_project'), 'fk_project', 0, 0, 1, 0, 0, 0, 0, '', 1, 0, 'maxwidth500');
+		print '</td></tr>';
+
+		// Show project on control
+		print '<tr><td>' . $langs->trans('ShowProjectOnControl') . ' ' . img_picto($langs->trans('ShowProjectOnControlHelp'), 'help') . '</td><td>';
+		print $form::selectarray('ctrl_show_project', [0 => $langs->trans('No'), 1 => $langs->trans('Yes')], GETPOSTISSET('ctrl_show_project') ? GETPOST('ctrl_show_project') : 1);
 		print '</td></tr>';
 	}
 
 	// Default control tags
 	if (!empty($conf->categorie->enabled)) {
-		print '<tr><td>' . $langs->trans('DefaultControlTags') . ' ' . img_picto($langs->trans('DefaultControlTagsHelp'), 'help') . '</td><td>';
+		print '<tr><td>' . img_picto('', 'category', 'class="paddingrightonly"') . $langs->trans('DefaultControlTags') . ' ' . img_picto($langs->trans('DefaultControlTagsHelp'), 'help') . '</td><td>';
 		$controlCateArbo = $form->select_all_categories('control', '', 'parent', 64, 0, 1);
-		print img_picto('', 'category', 'class="pictofixedwidth"') . $form::multiselectarray('default_control_tags', $controlCateArbo, GETPOST('default_control_tags', 'array'), '', 0, 'minwidth100imp maxwidth500 widthcentpercentminusxx');
+		print $form::multiselectarray('default_control_tags', $controlCateArbo, GETPOST('default_control_tags', 'array'), '', 0, 'minwidth100imp maxwidth500 widthcentpercentminusxx');
 		print '</td></tr>';
 
 		// Show tags on control
 		print '<tr><td>' . $langs->trans('ShowTagsOnControl') . ' ' . img_picto($langs->trans('ShowTagsOnControlHelp'), 'help') . '</td><td>';
 		print $form::selectarray('ctrl_show_tags', [0 => $langs->trans('No'), 1 => $langs->trans('Yes')], GETPOSTISSET('ctrl_show_tags') ? GETPOST('ctrl_show_tags') : 1);
 		print '</td></tr>';
-	}
-
-	if (!empty($conf->categorie->enabled)) {
-		// Categories
-		print '<tr><td class="fieldrequired">'.$langs->trans("Categories").'</td><td>';
-		$cate_arbo = $form->select_all_categories('sheet', '', 'parent', 64, 0, 1);
-		print img_picto('', 'category', 'class="pictofixedwidth"').$form::multiselectarray('categories', $cate_arbo, GETPOST('categories', 'array'), '', 0, 'minwidth100imp maxwidth500 widthcentpercentminusxx');
-        print '<a class="butActionNew" href="' . DOL_URL_ROOT . '/categories/index.php?type=sheet&backtopage=' . urlencode($_SERVER['PHP_SELF'] . '?action=create') . '" target="_blank"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans('AddCategories') . '"></span></a>';
-		print "</td></tr>";
 	}
 
     // Linked elements
@@ -623,38 +623,9 @@ if (($id || $ref) && $action == 'edit') {
     print $form::selectarray('type', $object->fields['type']['arrayofkeyval'], $object->type);
     print '</td></tr>';
 
-	// Control creation options
-	print '<tr class="liste_titre"><td colspan="2">' . $langs->trans('ControlCreationOptions') . '</td></tr>';
-
-	// Show project on control
-	if (!empty($conf->projet->enabled)) {
-		print '<tr><td>' . $langs->trans('ShowProjectOnControl') . ' ' . img_picto($langs->trans('ShowProjectOnControlHelp'), 'help') . '</td><td>';
-		print $form::selectarray('ctrl_show_project', [0 => $langs->trans('No'), 1 => $langs->trans('Yes')], GETPOSTISSET('ctrl_show_project') ? GETPOST('ctrl_show_project') : $object->show_project);
-		print '</td></tr>';
-
-		// Default project for control
-		print '<tr><td>' . img_picto('', 'project', 'class="paddingrightonly"') . $langs->trans('DefaultControlProject') . '</td><td>';
-		print $formproject->select_projects(-1, $object->fk_project, 'fk_project', 0, 0, 1, 0, 0, 0, 0, '', 1, 0, 'maxwidth500');
-		print '</td></tr>';
-	}
-
-	// Default control tags
-	if (!empty($conf->categorie->enabled)) {
-		print '<tr><td>' . $langs->trans('DefaultControlTags') . ' ' . img_picto($langs->trans('DefaultControlTagsHelp'), 'help') . '</td><td>';
-		$controlCateArbo = $form->select_all_categories('control', '', 'parent', 64, 0, 1);
-		$defaultControlTagsSelected = GETPOSTISSET('default_control_tags') ? GETPOST('default_control_tags', 'array') : (json_decode($object->default_control_tags ?? '[]', true) ?: []);
-		print img_picto('', 'category', 'class="pictofixedwidth"') . $form::multiselectarray('default_control_tags', $controlCateArbo, $defaultControlTagsSelected, '', 0, 'minwidth100imp maxwidth500 widthcentpercentminusxx');
-		print '</td></tr>';
-
-		// Show tags on control
-		print '<tr><td>' . $langs->trans('ShowTagsOnControl') . ' ' . img_picto($langs->trans('ShowTagsOnControlHelp'), 'help') . '</td><td>';
-		print $form::selectarray('ctrl_show_tags', [0 => $langs->trans('No'), 1 => $langs->trans('Yes')], GETPOSTISSET('ctrl_show_tags') ? GETPOST('ctrl_show_tags') : $object->show_tags);
-		print '</td></tr>';
-	}
-
 	// Tags-Categories
 	if ($conf->categorie->enabled) {
-		print '<tr><td class="fieldrequired">'.$langs->trans("Categories").'</td><td>';
+		print '<tr><td class="fieldrequired">' . img_picto('', 'category', 'class="paddingrightonly"') . $langs->trans("Categories").'</td><td>';
 		$cate_arbo = $form->select_all_categories('sheet', '', 'parent', 64, 0, 1);
 		$c = new Categorie($db);
 		$cats = $c->containing($object->id, 'sheet');
@@ -664,9 +635,37 @@ if (($id || $ref) && $action == 'edit') {
 				$arrayselected[] = $cat->id;
 			}
 		}
-		print img_picto('', 'category', 'class="pictofixedwidth"').$form::multiselectarray('categories', $cate_arbo, (GETPOSTISSET('categories') ? GETPOST('categories', 'array') : $arrayselected), '', 0, 'minwidth100imp maxwidth500 widthcentpercentminusxx');
-        print '<a class="butActionNew" href="' . DOL_URL_ROOT . '/categories/index.php?type=sheet&backtopage=' . urlencode($_SERVER['PHP_SELF'] . '?action=create') . '" target="_blank"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans('AddCategories') . '"></span></a>';
+		print $form::multiselectarray('categories', $cate_arbo, (GETPOSTISSET('categories') ? GETPOST('categories', 'array') : $arrayselected), '', 0, 'minwidth100imp maxwidth500 widthcentpercentminusxx');
 		print "</td></tr>";
+	}
+
+	// Control creation options
+	print '<tr class="liste_titre"><td colspan="2"><b>' . $langs->trans('ControlCreationOptions') . '</b></td></tr>';
+
+	// Default project for control
+	if (!empty($conf->projet->enabled)) {
+		print '<tr><td>' . img_picto('', 'project', 'class="paddingrightonly"') . $langs->trans('DefaultControlProject') . '</td><td>';
+		print $formproject->select_projects(-1, $object->fk_project, 'fk_project', 0, 0, 1, 0, 0, 0, 0, '', 1, 0, 'maxwidth500');
+		print '</td></tr>';
+
+		// Show project on control
+		print '<tr><td>' . $langs->trans('ShowProjectOnControl') . ' ' . img_picto($langs->trans('ShowProjectOnControlHelp'), 'help') . '</td><td>';
+		print $form::selectarray('ctrl_show_project', [0 => $langs->trans('No'), 1 => $langs->trans('Yes')], GETPOSTISSET('ctrl_show_project') ? GETPOST('ctrl_show_project') : $object->show_project);
+		print '</td></tr>';
+	}
+
+	// Default control tags
+	if (!empty($conf->categorie->enabled)) {
+		print '<tr><td>' . img_picto('', 'category', 'class="paddingrightonly"') . $langs->trans('DefaultControlTags') . ' ' . img_picto($langs->trans('DefaultControlTagsHelp'), 'help') . '</td><td>';
+		$controlCateArbo = $form->select_all_categories('control', '', 'parent', 64, 0, 1);
+		$defaultControlTagsSelected = GETPOSTISSET('default_control_tags') ? GETPOST('default_control_tags', 'array') : (json_decode($object->default_control_tags ?? '[]', true) ?: []);
+		print $form::multiselectarray('default_control_tags', $controlCateArbo, $defaultControlTagsSelected, '', 0, 'minwidth100imp maxwidth500 widthcentpercentminusxx');
+		print '</td></tr>';
+
+		// Show tags on control
+		print '<tr><td>' . $langs->trans('ShowTagsOnControl') . ' ' . img_picto($langs->trans('ShowTagsOnControlHelp'), 'help') . '</td><td>';
+		print $form::selectarray('ctrl_show_tags', [0 => $langs->trans('No'), 1 => $langs->trans('Yes')], GETPOSTISSET('ctrl_show_tags') ? GETPOST('ctrl_show_tags') : $object->show_tags);
+		print '</td></tr>';
 	}
 
     // Linked elements
@@ -675,14 +674,14 @@ if (($id || $ref) && $action == 'edit') {
 	$elementLinked = json_decode($object->element_linked ?? '{}') ?? new stdClass();
 
 	foreach ($objectsMetadata as $key => $element) {
-		if (empty($element['conf'])) {
+		if (empty($elementLinked->$key) || empty($element['conf'])) {
 			continue;
 		}
 		print '<tr><td class="">' . img_picto('', $element['picto'], 'class="paddingrightonly"') . $langs->trans($element['langs']) . '</td><td>';
 		if ($conf->global->DIGIQUALI_SHEET_UNIQUE_LINKED_ELEMENT) {
-			print '<input type="radio" id="show_' . $key . '" name="linked_object[]" value="'.$key.'"'.(!empty($elementLinked->$key) ? 'checked=checked' : '').'>';
+			print '<input type="radio" id="show_' . $key . '" name="linked_object[]" value="'.$key.'"'.(!empty($elementLinked->$key) ? ' checked=checked' : '').' disabled>';
 		} else {
-			print '<input type="checkbox" id="show_' . $key . '" name="linked_object[]" value="'.$key.'"'.(!empty($elementLinked->$key) ? 'checked=checked' : '').'>';
+			print '<input type="checkbox" id="show_' . $key . '" name="linked_object[]" value="'.$key.'"'.(!empty($elementLinked->$key) ? ' checked=checked' : '').' disabled>';
 		}
 		print '</td></tr>';
 	}
@@ -779,22 +778,17 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 	// Categories
 	if ($conf->categorie->enabled) {
-		print '<tr><td class="valignmiddle">'.$langs->trans("Categories").'</td><td>';
+		print '<tr><td class="valignmiddle">' . img_picto('', 'category', 'class="paddingrightonly"') . $langs->trans("Categories").'</td><td>';
 		print $form->showCategories($object->id, 'sheet', 1);
 		print "</td></tr>";
 	}
 
 	// Control creation options
-	print '<tr class="liste_titre"><td colspan="2">' . $langs->trans('ControlCreationOptions') . '</td></tr>';
+	print '<tr class="liste_titre"><td colspan="2"><b>' . $langs->trans('ControlCreationOptions') . '</b></td></tr>';
 
-	// Show project on control
+	// Default project for control
 	if (!empty($conf->projet->enabled)) {
-		print '<tr><td class="titlefield">' . $langs->trans('ShowProjectOnControl') . '</td><td>';
-		print yn($object->show_project);
-		print '</td></tr>';
-
-		// Default project for control
-		print '<tr><td>' . img_picto('', 'project', 'class="paddingrightonly"') . $langs->trans('DefaultControlProject') . '</td><td>';
+		print '<tr><td class="titlefield">' . img_picto('', 'project', 'class="paddingrightonly"') . $langs->trans('DefaultControlProject') . '</td><td>';
 		if (!empty($object->fk_project)) {
 			$tmpProject = new Project($db);
 			$tmpProject->fetch($object->fk_project);
@@ -803,11 +797,16 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			print '<span class="opacitymedium">' . $langs->trans('None') . '</span>';
 		}
 		print '</td></tr>';
+
+		// Show project on control
+		print '<tr><td>' . $langs->trans('ShowProjectOnControl') . '</td><td>';
+		print yn($object->show_project);
+		print '</td></tr>';
 	}
 
 	// Default control tags
 	if (!empty($conf->categorie->enabled)) {
-		print '<tr><td>' . $langs->trans('DefaultControlTags') . '</td><td>';
+		print '<tr><td>' . img_picto('', 'category', 'class="paddingrightonly"') . $langs->trans('DefaultControlTags') . '</td><td>';
 		$defaultControlTagIds = json_decode($object->default_control_tags ?? '[]', true) ?: [];
 		if (!empty($defaultControlTagIds)) {
 			$tmpCategory = new Categorie($db);
@@ -900,7 +899,11 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			}
 
 			// Modify
-			print '<a class="butAction" id="actionButtonEdit" href="' . $_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=edit' . '"><i class="fas fa-edit"></i> ' . $langs->trans('Modify') . '</a>';
+			if ($object->status != $object::STATUS_LOCKED) {
+				print '<a class="butAction" id="actionButtonEdit" href="' . $_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=edit' . '"><i class="fas fa-edit"></i> ' . $langs->trans('Modify') . '</a>';
+			} else {
+				print '<span class="butActionRefused classfortooltip" title="' . dol_escape_htmltag($langs->trans('ObjectMustBeUnlocked', ucfirst($langs->transnoentities('The' . ucfirst($object->element))))) . '"><i class="fas fa-edit"></i> ' . $langs->trans('Modify') . '</span>';
+			}
 
 			// Lock
 			if ($object->status == $object::STATUS_VALIDATED) {


### PR DESCRIPTION
## Description
Implementation de l'issue #2455 : ajout des options de creation du controle sur le formulaire du modele (Sheet).

## Changements

### SQL
- Ajout des colonnes `show_project`, `show_tags`, `default_control_tags` dans `llx_digiquali_sheet`
- Script de migration `update.sql` pour la version 23.2.0

### Classe Sheet
- Ajout des proprietes `show_project`, `show_tags`, `default_control_tags` dans `\` et en tant que proprietes PHP

### Formulaire sheet_card.php (CREATE / EDIT / VIEW)
- **Tags/categories** : deplace juste apres le champ Type, icone categorie dans le label
- **Options de creation du controle** (titre en gras) :
  - Projet par defaut du controle (avec icone projet)
  - Afficher le projet sur le controle (Oui/Non + aide)
  - Tags par defaut du controle (avec icone categorie + aide)
  - Afficher les tags sur le controle (Oui/Non + aide)
- **Objets controles** : titre en gras, radios/checkboxes desactives en mode EDIT
- **Bouton Modifier** : grise quand le modele est verrouille

### Traductions (fr_FR)
- Ajout des cles : `ShowProjectOnControl`, `ShowTagsOnControl`, `DefaultControlTags`, `ControlCreationOptions`, `DefaultControlProject` + descriptions d'aide

## Issue
Closes #2455