### PR TITLE
#2459 [Question] Fix: PHP warnings in question_card.php, sheet.class.php, answer.class.php

### DIFF
--- a/class/answer.class.php
+++ b/class/answer.class.php
@@ -242,7 +242,7 @@ class Answer extends SaturneObject
         if ($resql) {
             $obj = $this->db->fetch_object($resql);
             $positionField = 'position';
-            return $obj->$positionField;
+            return $obj ? $obj->$positionField : 0;
         } else {
             return 0;
         }

--- a/class/sheet.class.php
+++ b/class/sheet.class.php
@@ -553,6 +553,7 @@ class Sheet extends SaturneObject
     public function updateQuestionsAndGroupsPosition(?array $questionIds, ?array $questionGroupIds, $reindexLast = false, ?int $fk_source = null, string $sourcetype = 'digiquali_sheet')
     {
         $this->db->begin();
+        $error = 0;
 
         if (is_null($fk_source)) {
             $fk_source = $this->id;

--- a/view/question/question_card.php
+++ b/view/question/question_card.php
@@ -197,7 +197,7 @@ if (empty($reshook)) {
 			}
 		}
 
-		if ( ! $error && ! empty($conf->global->MAIN_UPLOAD_DOC)) {
+		if ( ! $error && ! empty($conf->global->MAIN_UPLOAD_DOC) && isset($_FILES['userfile'])) {
 			// Define relativepath and upload_dir
 			$relativepath                                             = '/question/tmp/QU0/photo_ok';
 			$upload_dir                                               = $conf->digiquali->multidir_output[$conf->entity] . '/' . $relativepath;
@@ -225,7 +225,7 @@ if (empty($reshook)) {
 			$error = 0;
 		}
 
-		if ( ! $error && ! empty($conf->global->MAIN_UPLOAD_DOC)) {
+		if ( ! $error && ! empty($conf->global->MAIN_UPLOAD_DOC) && isset($_FILES['userfile2'])) {
 			// Define relativepath and upload_dir
 			$relativepath                                             = '/question/tmp/QU0/photo_ko';
 			$upload_dir                                               = $conf->digiquali->multidir_output[$conf->entity] . '/' . $relativepath;


### PR DESCRIPTION
## Description
Corrige plusieurs warnings PHP sur la page question_card.php et les classes associees.

## Corrections

### question_card.php
- Ajout `isset(\['userfile'])` (ligne 200) et `isset(\['userfile2'])` (ligne 228) avant d'acceder aux elements du tableau `\` pour eviter les warnings `Undefined array key` quand aucun fichier n'est uploade
- Corrige aussi le warning `Cannot modify header information - headers already sent` qui etait cause par les warnings precedents

### sheet.class.php (ligne 555)
- Initialisation de `\ = 0` au debut de `updateQuestionsAndGroupsPosition()` pour eviter `Undefined variable \`

### answer.class.php (ligne 245)
- Ajout d'une verification null sur `\` dans `getMaxPosition()` pour eviter `Attempt to read property on null` quand la requete ne retourne aucun resultat

Closes #2459