### PR TITLE
#2461 [Sheet] Fix: Disable Modify button when sheet is archived

### DIFF
--- a/view/sheet/sheet_card.php
+++ b/view/sheet/sheet_card.php
@@ -899,7 +899,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			}
 
 			// Modify
-			if ($object->status != $object::STATUS_LOCKED) {
+			if ($object->status != $object::STATUS_LOCKED && $object->status != $object::STATUS_ARCHIVED) {
 				print '<a class="butAction" id="actionButtonEdit" href="' . $_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=edit' . '"><i class="fas fa-edit"></i> ' . $langs->trans('Modify') . '</a>';
 			} else {
 				print '<span class="butActionRefused classfortooltip" title="' . dol_escape_htmltag($langs->trans('ObjectMustBeUnlocked', ucfirst($langs->transnoentities('The' . ucfirst($object->element))))) . '"><i class="fas fa-edit"></i> ' . $langs->trans('Modify') . '</span>';


### PR DESCRIPTION
## Description
Le bouton Modifier est actif quand le modele est au statut Archive. Il devrait etre grise comme pour le statut Verrouille.

## Correction
Ajout de la condition `\->status != \::STATUS_ARCHIVED` dans la verification du bouton Modifier dans `sheet_card.php`.

## Fichier modifie
- `view/sheet/sheet_card.php` : le bouton Modifier est maintenant grise pour les statuts Verrouille ET Archive

Closes #2461