### PR TITLE
#2463 [QuestionGroup] Fix: Undefined array key digiquali_question on clone

### DIFF
--- a/class/questiongroup.class.php
+++ b/class/questiongroup.class.php
@@ -337,7 +337,7 @@ class QuestionGroup extends SaturneObject
         $previousObject = clone $object;
         $object->fetchObjectLinked('', '', $this->id, $this->table_element);
 
-        $previousQuestions = $object->linkedObjects['digiquali_question'];
+        $previousQuestions = $object->linkedObjects['digiquali_question'] ?? [];
 
 		// Reset some properties
 		unset($object->id);


### PR DESCRIPTION
## Description
Lors du clonage d'un modele, un warning `Undefined array key digiquali_question` apparait dans `questiongroup.class.php` ligne 340, suivi d'un `Cannot modify header information`.

## Correction
Ajout de l'operateur `??` pour defaulter a un tableau vide quand la cle `digiquali_question` n'existe pas dans `linkedObjects`.

## Fichier modifie
- `class/questiongroup.class.php:340` : `\->linkedObjects['digiquali_question'] ?? []`

Closes #2463