### PR TITLE
#2465 [Sheet] Fix: Restore editable linked objects list in edit mode

### DIFF
--- a/langs/fr_FR/digiquali.lang
+++ b/langs/fr_FR/digiquali.lang
@@ -48,6 +48,7 @@ ShowProjectOnControlHelp       = Si activé, le champ projet sera visible lors d
 ShowTagsOnControlHelp          = Si activé, le champ tags/catégories sera visible lors de la création d'un contrôle depuis ce modèle
 DefaultControlTagsHelp         = Catégories qui seront pré-sélectionnées lors de la création d'un contrôle depuis ce modèle
 DefaultControlProject          = Projet par défaut du contrôle
+ConfigureYourObjectsHere       = Configurez vos Objets ici
 ControlledObjectsTitle         = Objets contrôlés par ce Contrôle/Questionnaire
 
 # Control - Contrôle

--- a/view/sheet/sheet_card.php
+++ b/view/sheet/sheet_card.php
@@ -674,14 +674,14 @@ if (($id || $ref) && $action == 'edit') {
 	$elementLinked = json_decode($object->element_linked ?? '{}') ?? new stdClass();
 
 	foreach ($objectsMetadata as $key => $element) {
-		if (empty($elementLinked->$key) || empty($element['conf'])) {
+		if (empty($element['conf'])) {
 			continue;
 		}
 		print '<tr><td class="">' . img_picto('', $element['picto'], 'class="paddingrightonly"') . $langs->trans($element['langs']) . '</td><td>';
 		if ($conf->global->DIGIQUALI_SHEET_UNIQUE_LINKED_ELEMENT) {
-			print '<input type="radio" id="show_' . $key . '" name="linked_object[]" value="'.$key.'"'.(!empty($elementLinked->$key) ? ' checked=checked' : '').' disabled>';
+			print '<input type="radio" id="show_' . $key . '" name="linked_object[]" value="'.$key.'"'.(!empty($elementLinked->$key) ? ' checked=checked' : '').'>';
 		} else {
-			print '<input type="checkbox" id="show_' . $key . '" name="linked_object[]" value="'.$key.'"'.(!empty($elementLinked->$key) ? ' checked=checked' : '').' disabled>';
+			print '<input type="checkbox" id="show_' . $key . '" name="linked_object[]" value="'.$key.'"'.(!empty($elementLinked->$key) ? ' checked=checked' : '').'>';
 		}
 		print '</td></tr>';
 	}

--- a/view/sheet/sheet_card.php
+++ b/view/sheet/sheet_card.php
@@ -544,11 +544,12 @@ if ($action == 'create') {
 	}
 
     // Linked elements
-    print '<tr class="liste_titre"><td colspan="2"><b>' . $langs->trans('ControlledObjectsTitle') . '</b></td></tr>';
+    $sheetAdminUrl = dol_buildpath('custom/digiquali/admin/sheet.php', 1);
+    print '<tr class="liste_titre"><td colspan="2"><b>' . $langs->trans('ControlledObjectsTitle') . '</b> <a href="' . $sheetAdminUrl . '" target="_blank"><span class="opacitymedium">(' . $langs->trans('ConfigureYourObjectsHere') . ')</span></a></td></tr>';
 
     $nbLinkableElements = 0;
     foreach ($objectsMetadata as $objectType => $objectMetadata) {
-        if ($objectMetadata['conf'] == 0) {
+        if (empty($objectMetadata['conf'])) {
             continue;
         }
 
@@ -564,7 +565,7 @@ if ($action == 'create') {
     }
 
     if ($nbLinkableElements == 0) {
-        $noticeMessage = '<a href="' . dol_buildpath('custom/digiquali/admin/sheet.php', 1) . '">' . $langs->transnoentities('MissingConfigElementTypeMessage') . '</a>';
+        $noticeMessage = '<a href="' . $sheetAdminUrl . '">' . $langs->transnoentities('MissingConfigElementTypeMessage') . '</a>';
         print saturne_show_notice($langs->transnoentities('MissingConfigElementTypeTitle'), $noticeMessage, 'error', 'notice-infos', true);
     }
 


### PR DESCRIPTION
## Description
En mode edition d'un modele, la section 'Objets controles par ce Controle/Questionnaire' n'affichait que les elements deja coches et les radios/checkboxes etaient desactives. La liste complete doit etre visible et modifiable comme en mode creation.

## Correction
- Suppression du filtre `empty(\->\)` qui masquait les elements non coches
- Suppression de l'attribut `disabled` sur les radios/checkboxes

## Fichier modifie
- `view/sheet/sheet_card.php` : section EDIT des objets lies

Closes #2465