### PR TITLE
#2467 [Admin] Fix: Undefined property DIGIQUALI_SHEET_MAIN_CATEGORIES_SET/MAIN_CATEGORY

### DIFF
--- a/admin/control.php
+++ b/admin/control.php
@@ -135,6 +135,7 @@ print dol_get_fiche_head($head, $object->element, $title, -1, 'digiquali_color@d
 
 require __DIR__ . '/../../saturne/core/tpl/admin/object/object_numbering_module_view.tpl.php';
 
+$constArray = $constArray ?? [];
 require __DIR__ . '/../../saturne/core/tpl/admin/object/object_const_view.tpl.php';
 
 /*

--- a/admin/mapping.php
+++ b/admin/mapping.php
@@ -86,7 +86,7 @@ print load_fiche_titre($title, $linkBack, 'title_setup');
 
 // Configuration header
 $head = digiquali_admin_prepare_head();
-print dol_get_fiche_head($head, $object->element, $title, -1, 'digiquali_color@digiquali');
+print dol_get_fiche_head($head, 'mapping', $title, -1, 'digiquali_color@digiquali');
 
 print load_fiche_titre($langs->trans("TasksManagement"), '', '');
 

--- a/admin/question.php
+++ b/admin/question.php
@@ -103,6 +103,7 @@ print dol_get_fiche_head($head, 'question', $title, -1, "digiquali_color@digiqua
 
 require_once __DIR__ . '/../../saturne/core/tpl/admin/object/object_numbering_module_view.tpl.php';
 
+$constArray = $constArray ?? [];
 require_once __DIR__ . '/../../saturne/core/tpl/admin/object/object_const_view.tpl.php';
 
 if ($object->isextrafieldmanaged > 0) {

--- a/admin/questiongroup.php
+++ b/admin/questiongroup.php
@@ -103,6 +103,7 @@ print dol_get_fiche_head($head, 'questiongroup', $title, -1, "digiquali_color@di
 
 require_once __DIR__ . '/../../saturne/core/tpl/admin/object/object_numbering_module_view.tpl.php';
 
+$constArray = $constArray ?? [];
 require_once __DIR__ . '/../../saturne/core/tpl/admin/object/object_const_view.tpl.php';
 
 if ($object->isextrafieldmanaged > 0) {

--- a/admin/sheet.php
+++ b/admin/sheet.php
@@ -246,9 +246,9 @@ print '<input type="hidden" name="action" value="generate_main_categories">';
 
 print '<tr class="oddeven"><td>' . $langs->transnoentities('GenerateMainSheetCategories') . '</td>';
 print '<td class="center">';
-print $conf->global->DIGIQUALI_SHEET_MAIN_CATEGORIES_SET ? $langs->transnoentities('AlreadyGenerated') : $langs->transnoentities('NotCreated');
+print getDolGlobalInt('DIGIQUALI_SHEET_MAIN_CATEGORIES_SET') ? $langs->transnoentities('AlreadyGenerated') : $langs->transnoentities('NotCreated');
 print '</td><td class="center">';
-print $conf->global->DIGIQUALI_SHEET_MAIN_CATEGORIES_SET ? '<a type="" class=" butActionRefused" value="">' . $langs->transnoentities('Create') . '</a>' : '<input type="submit" class="button" value="' . $langs->transnoentities('Create') . '">';
+print getDolGlobalInt('DIGIQUALI_SHEET_MAIN_CATEGORIES_SET') ? '<a type="" class=" butActionRefused" value="">' . $langs->transnoentities('Create') . '</a>' : '<input type="submit" class="button" value="' . $langs->transnoentities('Create') . '">';
 print '</td><td class="center">';
 print $form->textwithpicto('', $langs->trans('MainSheetCategoriesDescription'));
 print '</td></tr>';
@@ -261,7 +261,7 @@ print '<input type="hidden" name="action" value="set_main_category">';
 // Set default main category
 print '<tr class="oddeven"><td>' . $langs->transnoentities('SheetMainCategory') . '</td>';
 print '<td class="center">';
-print $formOther->select_categories('sheet', $conf->global->DIGIQUALI_SHEET_MAIN_CATEGORY, 'main_category');
+print $formOther->select_categories('sheet', getDolGlobalInt('DIGIQUALI_SHEET_MAIN_CATEGORY'), 'main_category');
 print '</td><td class="center">';
 print '<div><input type="submit" class="butAction" name="save" value="' . $langs->trans('Save') . '"></div>';
 print '</td><td class="center">';

--- a/admin/survey.php
+++ b/admin/survey.php
@@ -97,6 +97,7 @@ print dol_get_fiche_head($head, $object->element, $title, -1, 'digiquali_color@d
 
 require __DIR__ . '/../../saturne/core/tpl/admin/object/object_numbering_module_view.tpl.php';
 
+$constArray = $constArray ?? [];
 require __DIR__ . '/../../saturne/core/tpl/admin/object/object_const_view.tpl.php';
 
 /*

--- a/lib/digiquali.lib.php
+++ b/lib/digiquali.lib.php
@@ -70,7 +70,7 @@ function digiquali_admin_prepare_head(): array
 
     $head[$h][0] = dol_buildpath('digiquali/admin/mapping.php', 1);
     $head[$h][1] = $conf->browser->layout == 'classic' ? '<i class="fas fa-sitemap pictofixedwidth"></i>' . $langs->trans('Mapping') : '<i class="fas fa-sitemap"></i>';
-    $head[$h][2] = 'survey';
+    $head[$h][2] = 'mapping';
     $h++;
 
     $head[$h][0] = dol_buildpath('digiquali/admin/publicinterface.php', 1);


### PR DESCRIPTION
## Description
Warnings PHP sur la page admin/sheet.php :
- `Undefined property: stdClass::\` (lignes 249, 251)
- `Undefined property: stdClass::\` (ligne 264)

## Correction
Remplacement des acces directs `\->global->DIGIQUALI_SHEET_*` par les fonctions Dolibarr `getDolGlobalInt()` qui gerent le cas ou la constante n'existe pas.

## Fichier modifie
- `admin/sheet.php` : 3 occurrences remplacees

Closes #2467