### PR TITLE
#2469 [Hooks] Fix: Fatal error Call to member function on null in completeTabsHead

### DIFF
--- a/class/actions_digiquali.class.php
+++ b/class/actions_digiquali.class.php
@@ -602,6 +602,10 @@ class ActionsDigiquali
     {
         global $conf, $langs;
 
+        if ($object === null || !is_object($object)) {
+            return 0;
+        }
+
         if (strpos($parameters['context'], 'main') !== false) {
             if (!empty($parameters['head'])) {
                 foreach ($parameters['head'] as $headKey => $headTab) {


### PR DESCRIPTION
## Description
Erreur fatale sur la page de configuration du module BOM (et potentiellement d'autres pages admin) :

`	xt
Fatal error: Call to a member function fetchObjectLinked() on null
in actions_digiquali.class.php (completeTabsHead)
`

## Cause
Le hook `completeTabsHead` appelle `\->fetchObjectLinked()` sans verifier que `\` est non-null. Sur certaines pages de configuration de modules Dolibarr, `\` est null.

## Correction
Ajout d'un guard `if (\ === null || !is_object(\)) return 0;` en debut de la methode `completeTabsHead()`.

## Fichier modifie
- `class/actions_digiquali.class.php`

Closes #2469