### PR TITLE
#2471 [Contrôle] Retours user : tâches au changement de projet, modale tâche & PDF

### DIFF
--- a/class/control.class.php
+++ b/class/control.class.php
@@ -541,6 +541,53 @@ class Control extends SaturneObject
         return parent::setLocked($user, $noTrigger);
     }
 
+    /**
+     * Move every task related to this control to a new project.
+     *
+     * Moves both the master task (fk_master_task) and all tasks linked to the control lines,
+     * so the linked tasks follow the control when its project changes.
+     *
+     * @param  int<0,max> $newProjectId New project ID
+     * @param  User       $user         User that performs the action
+     * @return int<-1,1>                Return integer < 0 if KO, > 0 if OK
+     * @throws Exception
+     */
+    public function setLinkedTasksProject(int $newProjectId, User $user): int
+    {
+        if ($newProjectId <= 0) {
+            return 1;
+        }
+
+        require_once DOL_DOCUMENT_ROOT . '/projet/class/task.class.php';
+
+        $this->db->begin();
+
+        // Move the master task created with the control. The database column is fk_projet
+        if (!empty($this->fk_master_task)) {
+            $masterTask = new Task($this->db);
+            if ($masterTask->fetch($this->fk_master_task) > 0 && $masterTask->fk_project != $newProjectId) {
+                $masterTask->setValueFrom('fk_projet', $newProjectId, '', null, 'int', '', $user);
+            }
+        }
+
+        // Move every task linked to the control lines
+        $this->fetchLines();
+        if (is_array($this->lines)) {
+            foreach ($this->lines as $line) {
+                $line->fetchObjectLinked($line->id, $line->element);
+                foreach ($line->linkedObjects['project_task'] ?? [] as $task) {
+                    if ($task->fk_project != $newProjectId) {
+                        $task->setValueFrom('fk_projet', $newProjectId, '', null, 'int', '', $user);
+                    }
+                }
+            }
+        }
+
+        $this->db->commit();
+
+        return 1;
+    }
+
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 	/**
 	 *  Return if a control can be deleted

--- a/core/modules/digiquali/digiqualidocuments/controldocument/pdf_controldocument.modules.php
+++ b/core/modules/digiquali/digiqualidocuments/controldocument/pdf_controldocument.modules.php
@@ -928,7 +928,12 @@ class pdf_controldocument extends SaturneDocumentModel
         $wLabel  = $w - $wRef - $wDate - $wProg - 6;
 
         foreach ($tasks as $task) {
-            $rowH = 6;
+            $labelText = $task->label ?? '';
+
+            // Compute the row height so long task names wrap instead of overflowing the row
+            $pdf->SetFont('', '', 7);
+            $rowH = max(6, $pdf->getStringHeight($wLabel, $labelText));
+
             $this->checkPageBreak($pdf, $rowH + 1);
             $sy = $pdf->GetY();
 
@@ -937,13 +942,12 @@ class pdf_controldocument extends SaturneDocumentModel
 
             $pdf->SetTextColor(180, 100, 0);
             $pdf->SetFont('', 'B', 7);
-            $pdf->SetXY($x + 3, $sy + 1);
+            $pdf->SetXY($x + 3, $sy + ($rowH - 4) / 2);
             $pdf->Cell($wRef, 4, $task->ref, 0, 0, 'L');
 
             $pdf->SetTextColor(...$this->colorBlack);
             $pdf->SetFont('', '', 7);
-            $pdf->SetXY($x + 3 + $wRef, $sy + 1);
-            $pdf->Cell($wLabel, 4, $task->label, 0, 0, 'L');
+            $pdf->MultiCell($wLabel, 4, $labelText, 0, 'L', 0, 0, $x + 3 + $wRef, $sy + 1, true, 0, false, true, $rowH - 2, 'M', false);
 
             $dateStr = '';
             if (!empty($task->date_end)) {
@@ -953,14 +957,14 @@ class pdf_controldocument extends SaturneDocumentModel
             }
             $pdf->SetTextColor(...$this->colorGray);
             $pdf->SetFont('', '', 7);
-            $pdf->SetXY($x + 3 + $wRef + $wLabel, $sy + 1);
+            $pdf->SetXY($x + 3 + $wRef + $wLabel, $sy + ($rowH - 4) / 2);
             $pdf->Cell($wDate, 4, $dateStr, 0, 0, 'C');
 
             $prog    = (int)($task->progress ?? 0);
             $progRgb = $prog >= 100 ? [56, 161, 105] : ($prog > 0 ? [255, 152, 0] : [220, 53, 69]);
             $pdf->SetTextColor(...$progRgb);
             $pdf->SetFont('', 'B', 7);
-            $pdf->SetXY($x + 3 + $wRef + $wLabel + $wDate, $sy + 1);
+            $pdf->SetXY($x + 3 + $wRef + $wLabel + $wDate, $sy + ($rowH - 4) / 2);
             $pdf->Cell($wProg, 4, $prog . '%', 0, 0, 'C');
 
             $pdf->SetTextColor(0, 0, 0);

--- a/core/tpl/digiquali_answers_task_action.tpl.php
+++ b/core/tpl/digiquali_answers_task_action.tpl.php
@@ -80,6 +80,19 @@ if ($action == 'update_task' && !empty($permissionToAddTask)) {
     }
 
     $task->update($user);
+
+    // Sync the assigned user (responsable) of the task
+    if (array_key_exists('fk_user_assign', $data)) {
+        $existingContacts = $task->liste_contact(-1, 'internal', 0, 'TASKEXECUTIVE');
+        if (is_array($existingContacts)) {
+            foreach ($existingContacts as $existingContact) {
+                $task->delete_contact($existingContact['rowid']);
+            }
+        }
+        if ($data['fk_user_assign'] > 0) {
+            $task->add_contact($data['fk_user_assign'], 'TASKEXECUTIVE', 'internal');
+        }
+    }
     // @todo manage error
 }
 

--- a/core/tpl/modal/modal_task_edit.tpl.php
+++ b/core/tpl/modal/modal_task_edit.tpl.php
@@ -24,7 +24,7 @@
 /**
  * The following vars must be defined:
  * Global   : $langs
- * Objects  : $object, $task
+ * Objects  : $object, $task, $form
  */
 
 $taskInfos = get_task_infos($task); ?>
@@ -52,17 +52,23 @@ $taskInfos = get_task_infos($task); ?>
                         <input type="text" id="answer-task-label" name="label" value="<?php echo $task->label; ?>">
                     </label>
                 </div>
+                <div class="answer-task-affected">
+                    <label>
+                        <span class="title"><?php echo $langs->trans('AffectedTo'); ?></span>
+                        <?php echo $form->select_dolusers($taskInfos['task']['assigned_user_id'], 'answer-task-edit-assigned-user', 1); ?>
+                    </label>
+                </div>
                 <div class="answer-task-date wpeo-gridlayout grid-3">
                     <div>
                         <label>
                             <span class="title"><?php echo $langs->trans('DateStart'); ?></span>
-                            <?php print '<input type="datetime-local" id="answer-task-date-start" name="date_start" value="' . (!empty($task->date_start) ? dol_print_date($task->date_start, '%Y-%m-%dT%H:%M') : '') . '">'; ?>
+                            <?php print '<input type="datetime-local" id="answer-task-start-date" name="date_start" value="' . (!empty($task->date_start) ? dol_print_date($task->date_start, '%Y-%m-%dT%H:%M') : '') . '">'; ?>
                         </label>
                     </div>
                     <div>
                         <label>
                             <span class="title"><?php echo $langs->trans('Deadline'); ?></span>
-                            <?php print '<input type="datetime-local" id="answer-task-date-end" name="date_end" value="' . (!empty($task->date_end) ? dol_print_date($task->date_end, '%Y-%m-%dT%H:%M') : '') . '">'; ?>
+                            <?php print '<input type="datetime-local" id="answer-task-end-date" name="date_end" value="' . (!empty($task->date_end) ? dol_print_date($task->date_end, '%Y-%m-%dT%H:%M') : '') . '">'; ?>
                         </label>
                     </div>
                     <div>

--- a/js/modules/task.js
+++ b/js/modules/task.js
@@ -228,23 +228,25 @@ window.digiquali.task.updateTask = function() {
   const taskId = $this.data('task-id');
   const $task  = $(document).find(`#answer_task${taskId}`);
 
-  const label     = $form.find('#answer-task-label').val();
-  const startDate = $form.find('#answer-task-start-date').val();
-  const endDate   = $form.find('#answer-task-end-date').val();
-  const budget    = $form.find('#answer-task-budget').val();
-  const progress  = $form.find('#answer-task-progress').val();
+  const label          = $form.find('#answer-task-label').val();
+  const startDate       = $form.find('#answer-task-start-date').val();
+  const endDate         = $form.find('#answer-task-end-date').val();
+  const budget          = $form.find('#answer-task-budget').val();
+  const progress        = $form.find('#answer-task-progress').val();
+  const assignedUserId  = $form.find('[name="answer-task-edit-assigned-user"]').val();
 
   $.ajax({
     url: `${document.URL}&action=update_task&token=${token}`,
     type: 'POST',
     contentType: 'application/json; charset=utf-8',
     data: JSON.stringify({
-      task_id:    taskId,
-      label:      label,
-      date_start: startDate,
-      date_end:   endDate,
-      budget:     budget,
-      progress:   progress
+      task_id:        taskId,
+      label:          label,
+      date_start:     startDate,
+      date_end:       endDate,
+      budget:         budget,
+      progress:       progress,
+      fk_user_assign: assignedUserId
     }),
     success: function(resp) {
       $modal.removeClass('modal-active');

--- a/lib/digiquali_control.lib.php
+++ b/lib/digiquali_control.lib.php
@@ -370,12 +370,16 @@ function get_task_infos(Task $task): array
     $userTmp->fetch($task->fk_user_creat);
     $out['task']['author'] = $userTmp->getNomUrl(1);
 
-    $out['task']['assigned'] = [];
+    $out['task']['assigned']         = [];
+    $out['task']['assigned_user_id'] = 0;
     $assignedContacts = $task->liste_contact(-1, 'internal', 0, 'TASKEXECUTIVE');
     if (is_array($assignedContacts)) {
         foreach ($assignedContacts as $assignedContact) {
             $userTmp->fetch($assignedContact['id']);
             $out['task']['assigned'][] = $userTmp->getNomUrl(1);
+            if (empty($out['task']['assigned_user_id'])) {
+                $out['task']['assigned_user_id'] = $assignedContact['id'];
+            }
         }
     }
 

--- a/view/control/control_card.php
+++ b/view/control/control_card.php
@@ -238,6 +238,11 @@ if (empty($resHook)) {
     // Actions set_thirdparty, set_project
     require_once __DIR__ . '/../../../saturne/core/tpl/actions/banner_actions.tpl.php';
 
+    // Move linked tasks to the new project so they follow the control
+    if ($action == 'set_project' && $permissiontoadd) {
+        $object->setLinkedTasksProject(GETPOSTINT(GETPOST('project_key', 'aZ09')), $user);
+    }
+
     if ($action == 'set_categories' && $permissiontoadd) {
         if ($object->fetch($id) > 0) {
             $result = $object->setCategories(GETPOST('categories', 'array'));


### PR DESCRIPTION
Fixes #2471

Regroupe plusieurs retours utilisateurs sur la gestion des tâches du contrôle et le PDF.

## Changements

### `[Control]` Changement de projet — rapatriement des tâches
Nouvelle méthode `Control::setLinkedTasksProject()` appelée après l'action `set_project` : déplace la *master task* (`fk_master_task`) **et** toutes les tâches liées aux lignes du contrôle vers le nouveau projet (mise à jour de `projet_task.fk_projet`). Les tâches suivent désormais le contrôle.

### `[Task]` Modale d'édition de tâche
- Ajout du champ « Affecté à », pré-rempli avec le responsable courant (`get_task_infos()` expose maintenant `assigned_user_id`).
- L'action `update_task` synchronise le contact `TASKEXECUTIVE` (Responsable) : suppression de l'ancien, ajout du nouveau.
- Correction des dates non enregistrées : les identifiants des champs date de la modale (`answer-task-date-start/-end`) ne correspondaient pas à ceux lus par le JS (`answer-task-start-date/-end`). Les valeurs saisies n'étaient jamais envoyées.

### `[PDF]` Document de contrôle
`drawQuestionTasks()` utilisait `Cell()` (pas de retour à la ligne) pour le libellé de tâche : les noms longs débordaient. Passage en `MultiCell()` avec hauteur de ligne dynamique, comme le plan d'action.

## Notes
- `js/digiquali.min.js` n'est pas commité (compilé par la CI sur develop, conformément au workflow assets).

## Tests
- Changer le projet d'un contrôle ayant des tâches → vérifier qu'elles apparaissent sur le nouveau projet (master task + tâches des questions).
- Créer une tâche en affectant un responsable → éditer la tâche : le responsable est affiché et modifiable ; modifier les dates → bien enregistrées.
- Générer le PDF d'un contrôle avec un nom de tâche très long → le texte passe à la ligne sans déborder.
