### PR TITLE
#2475 [Control] Fix: Undefined variable object and undefined key createfromclone in create()

### DIFF
--- a/class/control.class.php
+++ b/class/control.class.php
@@ -326,7 +326,7 @@ class Control extends SaturneObject
             if (!empty($questions)) {
                 foreach ($questions as $question) {
                     $controlLine->ref         = $controlLine->getNextNumRef();
-                    $fk_element              = 'fk_'. $object->element;
+                    $fk_element              = 'fk_'. $this->element;
                     $controlLine->fk_control = $this->id;
                     $controlLine->fk_question = $question->id;
                     $controlLine->answer      = '';
@@ -338,7 +338,7 @@ class Control extends SaturneObject
                 }
             }
 
-            if ($this->context['createfromclone'] != 'createfromclone') {
+            if (($this->context['createfromclone'] ?? '') != 'createfromclone') {
                 $objectsMetadata = saturne_get_objects_metadata();
                 foreach ($objectsMetadata as $objectMetadata) {
                     if (!empty(GETPOST($objectMetadata['post_name'])) && GETPOST($objectMetadata['post_name']) > 0) {


### PR DESCRIPTION
## Description
Lors de la creation d'un controle, 3 warnings PHP dans `control.class.php` :

1. `Undefined variable \` (ligne 329)
2. `Attempt to read property element on null` (ligne 329)
3. `Undefined array key createfromclone` (ligne 341)

Ces warnings causent aussi `Cannot modify header information - headers already sent`.

## Correction
- Ligne 329 : `\->element` remplace par `\->element` (la variable `\` n'existe pas dans le scope de `create()`)
- Ligne 341 : `\->context['createfromclone']` protege avec l'operateur `??` pour eviter l'acces a une cle inexistante

## Fichier modifie
- `class/control.class.php`

Closes #2475