### PR TITLE
#2479 [Answers] fix: reload object lines after autosave so answer counters stay accurate

### DIFF
--- a/core/tpl/digiquali_answers_save_action.tpl.php
+++ b/core/tpl/digiquali_answers_save_action.tpl.php
@@ -111,6 +111,14 @@ if ($action == 'save') {
                 }
             }
         }
+
+        // The lines above are saved through their own ControlLine/SurveyLine instances, so the
+        // $object->lines loaded at the top of the page is now stale. Reload it so every counter
+        // recomputed further down (answered-questions progress bar, per-group answer counters and
+        // statistics) reflects the answer that was just saved, including questions inside groups.
+        if ($object->id > 0) {
+            $object->fetchLines();
+        }
     }
 
     if (GETPOSTISSET('public_interface')) {


### PR DESCRIPTION
## Contexte

Sur la fiche controle (et survey) en back-office, chaque clic sur une reponse declenche un enregistrement autosave en AJAX. Le compteur de reponses affiche (barre de progression globale + badges par groupe de questions) etait systematiquement en retard d'un cran : la reponse qu'on venait de cliquer n'etait pas comptee. Consequence : apres avoir repondu a toutes les questions, le controle paraissait incomplet et ne pouvait pas etre finalise sereinement. Effet plus visible sur les fiches a groupes (souvent les plus volumineuses).

## Cause racine

`$object` (et donc `$object->lines`) est charge en haut de page. L'action de sauvegarde enregistre la reponse via des instances `ControlLine` / `SurveyLine` distinctes, sans jamais rafraichir `$object->lines`. Le recalcul des compteurs plus bas dans la page (progress bar, compteurs par groupe via `calculatePoints()`, statistiques) se fait donc sur des lignes perimees.

## Changement

- Rechargement de `$object->lines` (`$object->fetchLines()`) juste apres la boucle d'enregistrement dans le template partage `digiquali_answers_save_action.tpl.php`.
- Les compteurs recalcules ensuite (barre de progression, badges par groupe, stats) refletent immediatement la reponse enregistree, y compris pour les questions situees dans des groupes.
- Le chemin interface publique redirige apres sauvegarde : comportement inchange.

## Validation

- Simulation avec transaction + rollback (aucune donnee modifiee) sur un controle reel utilisant des groupes : avant le fix le compteur restait a 0 apres sauvegarde, apres le fix il passe correctement a 1 (reponse KO reflete immediatement sur une question de groupe).
- `php -l` OK sur le fichier modifie.

## Fichiers modifies

- `core/tpl/digiquali_answers_save_action.tpl.php`

## Issue

#2479
