### PR TITLE
#2480 [Tools] fix: reject sheet import without controllable object

### DIFF
--- a/view/digiqualitools.php
+++ b/view/digiqualitools.php
@@ -395,6 +395,26 @@ if (GETPOST('dataMigrationImportZip', 'alpha') && $permissionToWrite) {
 
             if (is_array($digiqualiExportArray['sheets'] ?? null) && !empty($digiqualiExportArray['sheets'])) {
                 foreach ($digiqualiExportArray['sheets'] as $sheetSingle) {
+                    // A sheet must define at least one "objet à contrôler" (element_linked); without it,
+                    // no control can ever be created from the imported model. The creation form already
+                    // blocks this (NoLinkedObjectSelected), so the import must reject it too instead of
+                    // silently letting an unusable model enter the system.
+                    $linkedObjects         = json_decode($sheetSingle['element_linked'] ?? '', true);
+                    $hasControllableObject = false;
+                    if (is_array($linkedObjects)) {
+                        foreach ($linkedObjects as $isObjectLinked) {
+                            if (!empty($isObjectLinked)) {
+                                $hasControllableObject = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (!$hasControllableObject) {
+                        $error++;
+                        $dqLog('✗ Trame « ' . dol_trunc($sheetSingle['label'] ?? '', 60) . ' » ignorée : aucun objet à contrôler défini', 'error');
+                        continue;
+                    }
+
 					$sheet->ref_ext             = $sheetSingle['ref'];
                     $sheet->type                = $sheetSingle['type'];
                     $sheet->label               = $sheetSingle['label'];


### PR DESCRIPTION
## Contexte

Lors de l'import d'un modele (trame) via la page Outils (`view/digiqualitools.php`, import ZIP/JSON), si la trame importee n'a aucun "objet a controler" (`element_linked` vide ou absent), l'import se terminait **sans aucune erreur**. Resultat : une trame inutilisable entrait en base, depuis laquelle il etait ensuite impossible de creer le moindre controle.

## Cause racine

Le formulaire de creation de trame impose deja au moins un objet a controler (`NoLinkedObjectSelected`, `sheet_card.php`). L'import, lui, affectait `element_linked` sans aucune verification, laissant passer une donnee invalide silencieusement.

## Changement

- Ajout d'une validation dans la boucle d'import des trames : si `element_linked` ne contient aucun objet a controler actif, la trame est **ignoree** (non creee) et une erreur explicite est ajoutee a la console de diagnostic.
- L'echec est reflete dans la banniere de synthese (compteur "en echec"), comme les autres erreurs d'import.
- Comportement aligne sur le formulaire de creation : aucune trame sans objet a controler ne peut plus entrer en base.

## Validation

- Simulation de la boucle d'import (transaction + rollback, aucune donnee persistee) sur 3 trames :
  - `{"productlot":1}` -> importee (success)
  - `{}` -> ignoree + erreur console
  - champ absent -> ignoree + erreur console
  - Banniere : "1 element(s) importe(s), 2 en echec".
- Detection validee sur `{}`, `[]`, `""`, `{"x":0}`, cle absente -> tous rejetes ; `{"productlot":1}`, `{"user":1,"contact":1}` -> acceptes.
- `php -l` OK.

## Fichiers modifies

- `view/digiqualitools.php`

## Issue

#2480
