### PR TITLE
#2289 [Sheet] fix: remap mandatory_questions when cloning a sheet

### DIFF
--- a/class/questiongroup.class.php
+++ b/class/questiongroup.class.php
@@ -60,6 +60,12 @@ class QuestionGroup extends SaturneObject
      */
     public string $picto = 'fontawesome_fa-folder_fas_#d35968';
 
+    /**
+     * @var array<int,int> Source question ID => cloned question ID, filled by createFromClone (nested groups included).
+     *                     Lets the caller remap anything referencing question IDs, e.g. Sheet::mandatory_questions.
+     */
+    public array $clonedQuestionIds = [];
+
     public const STATUS_DELETED   = -1;
     public const STATUS_DRAFT     = 0;
     public const STATUS_VALIDATED = 1;
@@ -388,11 +394,16 @@ class QuestionGroup extends SaturneObject
                     $clonedQuestion = new Question($this->db);
                     $clonedQuestion->id = $clonedQuestion->createFromClone($user, $previousQuestion->id, []);
                     $clonedQuestion->add_object_linked('digiquali_' . $object->element, $object->id);
+
+                    $this->clonedQuestionIds[(int) $previousQuestion->id] = (int) $clonedQuestion->id;
                 } else {
                     $previousQuestionGroup = $previousQuestionOrGroup;
                     $clonedQuestionGroup = new QuestionGroup($this->db);
                     $clonedQuestionGroup->id = $clonedQuestionGroup->createFromClone($user, $previousQuestionGroup->id, []);
                     $clonedQuestionGroup->add_object_linked('digiquali_' . $object->element, $object->id);
+
+                    // Questions nested deeper in the tree must reach the caller too
+                    $this->clonedQuestionIds += $clonedQuestionGroup->clonedQuestionIds;
                 }
                 $sheet->updateQuestionsAndGroupsPosition(null, null, true, $object->id, 'digiquali_questiongroup');
             }

--- a/class/sheet.class.php
+++ b/class/sheet.class.php
@@ -356,6 +356,7 @@ class Sheet extends SaturneObject
 
             $questionIds = [];
             $questionGroupIds = [];
+            $clonedQuestionIds = [];
 
             if (is_array($questionAndGroups) && !empty($questionAndGroups)) {
                 foreach ($questionAndGroups as $position => $questionOrGroup) {
@@ -365,15 +366,20 @@ class Sheet extends SaturneObject
                         $clonedQuestion->id = $clonedQuestion->createFromClone($user, $questionOrGroup->id, []);
                         $clonedQuestion->add_object_linked('digiquali_' . $object->element, $sheetID);
                         $questionIds[$position+1] = $clonedQuestion->id;
+
+                        $clonedQuestionIds[(int) $questionOrGroup->id] = (int) $clonedQuestion->id;
                     } else {
                         $clonedQuestionGroup = new QuestionGroup($this->db);
                         $clonedQuestionGroup->id = $clonedQuestionGroup->createFromClone($user, $questionOrGroup->id, []);
                         $clonedQuestionGroup->add_object_linked('digiquali_' . $object->element, $sheetID);
                         $questionGroupIds[$position+1] = $clonedQuestionGroup->id;
+
+                        $clonedQuestionIds += $clonedQuestionGroup->clonedQuestionIds;
                     }
                 }
                 $object->updateQuestionsAndGroupsPosition($questionIds, $questionGroupIds);
 
+                $object->remapMandatoryQuestions($clonedQuestionIds, $user);
             }
         } else {
             $error++;
@@ -391,6 +397,38 @@ class Sheet extends SaturneObject
             $this->db->rollback();
             return -1;
         }
+    }
+
+    /**
+     * Rewrite mandatory_questions onto another set of questions.
+     *
+     * mandatory_questions stores raw question IDs. Cloning a sheet re-creates its questions with
+     * fresh IDs, so the copied JSON would still point at the source's questions: every mandatory
+     * flag would silently be lost. The import does the same remapping (view/digiqualitools.php).
+     *
+     * @param  array<int,int> $clonedQuestionIds Source question ID => new question ID
+     * @param  User           $user              User doing the update
+     * @return int<-1,1>                         < 0 if KO, > 0 if OK
+     */
+    public function remapMandatoryQuestions(array $clonedQuestionIds, User $user): int
+    {
+        $mandatoryQuestions = json_decode($this->mandatory_questions ?? '', true);
+
+        if (!is_array($mandatoryQuestions) || empty($mandatoryQuestions)) {
+            return 1;
+        }
+
+        $remappedQuestions = [];
+        foreach ($mandatoryQuestions as $mandatoryQuestionId) {
+            // IDs have been stored as int and as string over time, cast before looking them up
+            if (!empty($clonedQuestionIds[(int) $mandatoryQuestionId])) {
+                $remappedQuestions[] = $clonedQuestionIds[(int) $mandatoryQuestionId];
+            }
+        }
+
+        $this->mandatory_questions = !empty($remappedQuestions) ? json_encode($remappedQuestions) : '{}';
+
+        return $this->setValueFrom('mandatory_questions', $this->mandatory_questions, '', null, '', '', $user);
     }
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps


### PR DESCRIPTION
Closes #2289

## Problème

`mandatory_questions` stocke des ids de questions bruts. `Sheet::createFromClone()` recopie le JSON tel quel (via `fetchCommon()` puis `create()`) alors qu'il re-crée les questions du modèle avec de **nouveaux ids** juste après. Le clone pointe donc sur les questions de la source : toutes les questions obligatoires sont silencieusement perdues, et le JSON contient des ids qui n'appartiennent pas au modèle.

Reproduit sur `MO2408-0030` (16 questions, 15 obligatoires) : le clone reçoit les questions 228→243 mais conserve `mandatory_questions = [141,142,…,155,140]` → **0 question obligatoire** sur le clone.

## Correctif

- **`Sheet::remapMandatoryQuestions()`** réécrit le JSON à partir d'une table de correspondance `id source => id cloné`, construite pendant le clonage des questions. C'est le même remap que fait déjà l'import (`view/digiqualitools.php:428`). Persisté via `setValueFrom()` pour ne pas déclencher un `SHEET_MODIFY` parasite juste après la création.
- **`QuestionGroup::$clonedQuestionIds`** expose cette correspondance pour les questions **imbriquées dans un groupe** : `QuestionGroup::createFromClone()` les clonait récursivement sans jamais remonter leurs nouveaux ids, elles étaient donc impossibles à remapper depuis le modèle. La map des sous-groupes est fusionnée récursivement.

La correspondance se fait par id et non par position, donc l'ordre de clonage (groupe avant question directe, par exemple) n'a aucune incidence.

## Tests réalisés

Clonages exécutés en CLI dans une transaction annulée, puis validés dans l'IHM :

- **modèle plat** (`MO2408-0030`, 15 obligatoires sur 16) : les 15 flags sont remappés sur les questions du clone, 0 id orphelin, et la question non obligatoire reste bien exclue ;
- **modèle avec groupe** (fixture : 1 question directe + 1 groupe contenant 1 question obligatoire et 1 optionnelle) : les 2 obligatoires sont conservées, dont celle imbriquée, 0 id orphelin.

## Note

Les modèles déjà clonés avant ce correctif gardent des `mandatory_questions` incohérents en base (ids pointant hors du modèle). Ce PR empêche que ça se reproduise mais ne nettoie pas l'existant — à traiter séparément si besoin.