### PR TITLE
#2241 [Control] fix: fatal on percentage average when a question is unanswered

### DIFF
--- a/core/modules/digiquali/digiqualidocuments/surveydocument/doc_surveydocument_odt.modules.php
+++ b/core/modules/digiquali/digiqualidocuments/surveydocument/doc_surveydocument_odt.modules.php
@@ -303,8 +303,9 @@ class doc_surveydocument_odt extends SaturneDocumentModel
 
             $percentQuestionCounter++;
             foreach ($object->lines as $line) {
-                if ($line->fk_question === $questionLinked->id) {
-                    $averagePercentageQuestions += $line->answer;
+                // A line submitted with a blank percentage holds an empty string, which is a fatal in PHP 8: 0 + '' is a TypeError
+                if ($line->fk_question === $questionLinked->id && is_numeric($line->answer)) {
+                    $averagePercentageQuestions += (float) $line->answer;
                 }
             }
         }

--- a/view/control/control_card.php
+++ b/view/control/control_card.php
@@ -900,8 +900,9 @@ if ($object->id > 0 && (empty($action) || ($action != 'create'))) {
 
             $percentQuestionCounter++;
             foreach ($object->lines as $line) {
-                if ($line->fk_question === $questionLinked->id) {
-                    $averagePercentageQuestions += $line->answer;
+                // An unanswered line holds an empty string (Control::create), which is a fatal in PHP 8: 0 + '' is a TypeError
+                if ($line->fk_question === $questionLinked->id && is_numeric($line->answer)) {
+                    $averagePercentageQuestions += (float) $line->answer;
                 }
             }
         }


### PR DESCRIPTION
Closes #2241

## Problème

`Control::create()` initialise chaque ligne avec `answer = ''` (`class/control.class.php:332`). Le calcul de la moyenne des questions de type `Percentage` somme cette valeur telle quelle :

```php
$averagePercentageQuestions += $line->answer;   // view/control/control_card.php:904
```

En PHP 8, `0 + ''` lève `TypeError: Unsupported operand types: int + string`. **Ouvrir un contrôle dont le modèle contient une question `Percentage` non répondue est donc un fatal.**

Reproduit sous PHP 8.2 en rejouant le bloc `control_card.php:893-910` sur un contrôle réel : la comparaison stricte `$line->fk_question === $questionLinked->id` matche bien (deux entiers), `answer` vaut `''` → `TypeError`.

La capture de l'issue pointe la ligne 741, ce qui correspond exactement à cette instruction dans la 21.1.x installée chez le client (`git show 21.1.0:view/control/control_card.php`).

## Correctif

Garde `is_numeric()` + cast explicite, aux deux endroits où le motif est répété :

- `view/control/control_card.php:904`
- `core/modules/digiquali/digiqualidocuments/surveydocument/doc_surveydocument_odt.modules.php:307` (même calcul pour l'ODT questionnaire ; ici le `''` provient d'un pourcentage soumis vide, le reste de `survey.class.php` se garde déjà avec des `!= ''`)

`$percentQuestionCounter++` est laissé inchangé : une question non répondue continue de compter comme 0 % dans la moyenne, soit **exactement le rendu d'avant PHP 8** (où `0 + ''` valait 0 avec un simple warning). Aucun changement d'affichage, uniquement la disparition du fatal.

## Tests réalisés

Bloc **extrait du fichier source lui-même** puis évalué sous PHP 8.2 (aucune écriture en base) :

- questions `Percentage` non répondues (`answer = ''`) → moyenne `0 %`, plus aucun fatal (avant correctif : `TypeError`) ;
- réponse à `80 %` injectée en mémoire → moyenne `80 %`, calcul inchangé.

Vérifié également dans l'IHM sur une fiche contrôle qui plantait auparavant.

## Note

Si la moyenne ne doit porter que sur les questions **réellement répondues** (et non diluée par les questions vides comptées à 0 %), c'est une décision produit distincte, hors périmètre de ce correctif de fatal.