### PR TITLE
#2492 [List] feat: enable the Validate mass action on control and survey lists

### DIFF
--- a/view/control/control_list.php
+++ b/view/control/control_list.php
@@ -205,6 +205,9 @@ $permissiontodelete = $user->hasRight($object->module, $object->element, 'delete
 // Security check
 saturne_check_access($permissiontoread, $object);
 
+// Enable the "Validate" mass action offered by the saturne list templates
+$enableMassValidate = 1;
+
 /*
  * Actions
  */

--- a/view/survey/survey_list.php
+++ b/view/survey/survey_list.php
@@ -196,6 +196,9 @@ $permissiontodelete = $user->hasRight($object->module, $object->element, 'delete
 // Security check
 saturne_check_access($permissiontoread, $object);
 
+// Enable the "Validate" mass action offered by the saturne list templates
+$enableMassValidate = 1;
+
 /*
  * Actions
  */


### PR DESCRIPTION
Closes #2492

## Ce que fait la PR

Active l'action de masse **Valider** apportée par Saturne sur les deux listes :

- `view/control/control_list.php` — liste des contrôles
- `view/survey/survey_list.php` — liste des questionnaires

Une ligne par page (`$enableMassValidate = 1;`) : toute la mécanique est dans Saturne.

Seuls les enregistrements au statut brouillon sont validés ; les autres (verrouillés, archivés) sont ignorés avec un avertissement chiffré, sans faire échouer le reste du lot.

## Dépendance

Nécessite Evarisk/Saturne#1480. Sans elle, la variable n'a simplement aucun effet — pas de casse.

## Tests

Vérifié en local (Dolibarr 23, Playwright), un brouillon **et** un enregistrement verrouillé sélectionnés sur chaque liste :

```
Confirmation de validation en masse
Êtes-vous sûr de vouloir valider les 2 enregistrement(s) sélectionné(s) ?

1 enregistrement(s) validé(s)
1 enregistrement(s) ignoré(s) car ils ne sont pas au statut brouillon

contrôles      FC2602-0054 : Brouillon -> Validé   FC2512-0053 : Verrouillé -> Verrouillé
questionnaires SY2603-0135 : Brouillon -> Validé   SY2601-0111 : Verrouillé -> Verrouillé
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)