### PR TITLE
#2495 [Onglets] fix: onglets Contrôles et Questionnaires en double sur les contrats

### DIFF
--- a/core/modules/modDigiQuali.class.php
+++ b/core/modules/modDigiQuali.class.php
@@ -320,6 +320,10 @@ class modDigiQuali extends DolibarrModules
         $objectsMetadata = saturne_get_objects_metadata();
 
         foreach($objectsMetadata as $objectType => $objectMetadata) {
+            // Legacy alias keys point to an entry already handled, declaring them would duplicate its tabs and hooks
+            if (!empty($objectMetadata['alias_of'])) {
+                continue;
+            }
             if (preg_match('/_/', $objectType)) {
                 $splittedElementType = explode('_', $objectType);
                 $moduleName = $splittedElementType[0];


### PR DESCRIPTION
Closes #2495

## Problème

Sur toutes les pages d'une fiche contrat, les onglets **Contrôles DigiQuali** et **Questionnaires** apparaissaient deux fois.

`saturne_get_objects_metadata()` expose l'objet contrat sous deux clés (`contract` + l'alias de rétrocompatibilité `contrat`) portant le même `tab_type` et le même `link_name`. La boucle du descripteur déclarait donc l'onglet deux fois, et `complete_head_from_modules()` ne déduplique pas. Les hooks `contractlist` / `contractcard` étaient eux aussi enregistrés en double dans `MAIN_MODULE_DIGIQUALI_HOOKS`.

## Correctif

`continue` sur les entrées marquées `alias_of`.

⚠️ **Dépend de Evarisk/Saturne#1483** (à fusionner en premier) : c'est cette PR qui pose la clé `alias_of`.

⚠️ Les constantes `MAIN_MODULE_DIGIQUALI_TABS_*` déjà écrites en base ne se corrigent pas toutes seules — il faut **désactiver puis réactiver** le module. Une simple réactivation ne suffit pas : la liste perd 2 entrées, tous les index se décalent, et les 2 dernières constantes resteraient orphelines en créant d'autres onglets fantômes.

## Tests

Onglets d'une fiche contrat après régénération des constantes :

```
Contrat | Contacts/Adresses | Notes | Fichiers joints | Événements/Agenda
| DoliMeet | Horaires | Contrôles DigiQuali | Questionnaires
```

71 onglets déclarés, 0 doublon. `control_list.php?fromtype=contrat` répond 200 sans warning PHP ni erreur JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)