### PR TITLE
#2497 [Control/Survey] fix: keep the list alive when the linked sheet is gone

### DIFF
--- a/class/actions_digiquali.class.php
+++ b/class/actions_digiquali.class.php
@@ -888,9 +888,13 @@ class ActionsDigiquali
             $object->fetchLines();
             $object->fetchObjectLinked('', '', $object->id, 'digiquali_control');
 
-            $sheet->fetch($object->fk_sheet);
-            $sheet->fetchObjectLinked($object->fk_sheet, 'digiquali_' . $sheet->element, null, '', 'OR', 1, 'position');
-            $conf->cache['sheet'] = $sheet;
+            // A failed fetch() leaves the object as it was, so an unfetched sheet must not reach the cache
+            if ($sheet->fetch($object->fk_sheet) > 0) {
+                $sheet->fetchObjectLinked($object->fk_sheet, 'digiquali_' . $sheet->element, null, '', 'OR', 1, 'position');
+                $conf->cache['sheet'] = $sheet;
+            } else {
+                $conf->cache['sheet'] = null;
+            }
 
             $filter      = ['customsql' => 'fk_object = ' . $object->id . ' AND status > 0 AND object_type = "' . $object->element . '"'];
             $signatories = $signatory->fetchAll('', 'role', 0, 0, $filter);
@@ -969,7 +973,7 @@ class ActionsDigiquali
             $out = [];
 
             if ($parameters['key'] == 'fk_sheet') {
-                $out[$parameters['key']] = $conf->cache['sheet']->getNomUrl(1, '', 0, 'maxwidth200onsmartphone maxwidth300', -1, 1);
+                $out[$parameters['key']] = isset($conf->cache['sheet']) ? $conf->cache['sheet']->getNomUrl(1, '', 0, 'maxwidth200onsmartphone maxwidth300', -1, 1) : '';
             }
 
             if (!empty($object->linkedObjects)) {
@@ -1000,7 +1004,7 @@ class ActionsDigiquali
 
             if ($parameters['key'] == 'question_answered') {
                 $NbQuestion  = 0;
-                $questionIds = $conf->cache['sheet']->linkedObjectsIds['digiquali_question'] ?? [];
+                $questionIds = isset($conf->cache['sheet']) ? ($conf->cache['sheet']->linkedObjectsIds['digiquali_question'] ?? []) : [];
                 if (is_array($questionIds) && !empty($questionIds)) {
                     $NbQuestion = count($questionIds);
                     $NbAnswer   = 0;
@@ -1033,7 +1037,7 @@ class ActionsDigiquali
             }
 
             if ($parameters['key'] == 'average_percentage_questions' || $parameters['key'] == 'verdict_object') {
-                $questions = $conf->cache['sheet']->linkedObjects['digiquali_question'];
+                $questions = isset($conf->cache['sheet']) ? ($conf->cache['sheet']->linkedObjects['digiquali_question'] ?? []) : [];
                 if (is_array($questions) && !empty($questions)) {
                     $questions = array_column($questions, null, 'id');
                 }
@@ -1041,8 +1045,8 @@ class ActionsDigiquali
                 $answers = [];
                 if (is_array($object->lines) && !empty($object->lines)) {
                     foreach ($object->lines as $objectLine) {
-                        if ($questions[$objectLine->fk_question]->type !== 'Percentage') {
-                            continue; // Skip non-percentage questions
+                        if (!isset($questions[$objectLine->fk_question]) || $questions[$objectLine->fk_question]->type !== 'Percentage') {
+                            continue; // Skip questions the sheet no longer carries, and non-percentage ones
                         }
                         $answers[] = $objectLine->answer;
                     }


### PR DESCRIPTION
Closes #2497

Complément côté DigiQuali de Evarisk/Saturne#1481.

## Problème

`saturneSetVarsFromFetchObj()` mettait la `Sheet` en cache sans regarder ce que
`fetch()` retournait. Un `fetch()` raté ne réinitialise pas l'objet : une fiche vierge
partait en cache et `saturnePrintFieldListLoopObject()` la lisait comme si elle était
réelle — lien vers `sheet_card.php` sans id, et `Undefined index: digiquali_question`
sur la colonne `average_percentage_questions`.

Déclencheur observé : table `llx_digiquali_sheet` sans les colonnes 23.2.0, ce qui faisait
échouer **tous** les `Sheet::fetch()`. Un contrôle pointant une fiche supprimée produit
le même effet.

## Correction

La fiche n'entre dans le cache que si elle a réellement été chargée, et les trois
lecteurs vérifient sa présence. Un contrôle dont la fiche a disparu affiche une cellule
vide au lieu d'un lien mort.

## Vérification

Test sur un contrôle dont le `fk_sheet` pointe dans le vide, warnings PHP promus en erreurs :

| Cas | Avant | Après |
|---|---|---|
| `saturneSetVarsFromFetchObj` | OK | OK |
| colonne `fk_sheet` | lien vers une fiche inexistante | cellule vide |
| colonne `question_answered` | OK | OK |
| colonne `average_percentage_questions` | `Undefined index: digiquali_question` | OK |
| contrôle avec fiche valide | OK | OK |

Liste des contrôles rechargée : HTTP 200, 25 lignes, colonne Fiche renseignée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)