### PR TITLE
#2502 [Control/Survey] fix: drop the is_erasable override blocking every mass deletion

### DIFF
--- a/class/control.class.php
+++ b/class/control.class.php
@@ -588,51 +588,6 @@ class Control extends SaturneObject
         return 1;
     }
 
-	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
-	/**
-	 *  Return if a control can be deleted
-	 *
-	 *  @return    int         <=0 if no, >0 if yes
-	 */
-	public function is_erasable() {
-		return $this->isLinkedToOtherObjects();
-	}
-
-	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
-	/**
-	 *  Return if a control is linked to another object
-	 *
-	 *  @return    int         <=0 if no, >0 if yes
-	 */
-	public function isLinkedToOtherObjects() {
-
-		// Links between objects are stored in table element_element
-		$sql = 'SELECT rowid, fk_source, sourcetype, fk_target, targettype';
-		$sql .= ' FROM '.MAIN_DB_PREFIX.'element_element';
-		$sql .= ' WHERE fk_target = ' . $this->id;
-		$sql .= " AND targettype = '" . $this->table_element . "'";
-
-		$resql = $this->db->query($sql);
-
-		if ($resql) {
-			$nbObjectsLinked = 0;
-			$num = $this->db->num_rows($resql);
-			$i = 0;
-			while ($i < $num) {
-				$nbObjectsLinked++;
-				$i++;
-			}
-			if ($nbObjectsLinked > 0) {
-				return -1;
-			} else {
-				return 1;
-			}
-		} else {
-			dol_print_error($this->db);
-			return -1;
-		}
-	}
-
     /**
      * Clone an object into another one.
      *

--- a/class/survey.class.php
+++ b/class/survey.class.php
@@ -304,49 +304,6 @@ class Survey extends SaturneObject
     }
 
     /**
-     * Return if a survey can be deleted
-     *
-     * @return int 0 < if KO, > 0 if OK
-     */
-    public function is_erasable(): int
-    {
-        return $this->isLinkedToOtherObjects();
-    }
-
-    /**
-     * Return if a survey is linked to another object
-     *
-     * @return int 0 < if KO, > 0 if OK
-     */
-    public function isLinkedToOtherObjects(): int
-    {
-        // Links between objects are stored in table element_element
-        $sql = 'SELECT rowid, fk_source, sourcetype, fk_target, targettype';
-        $sql .= ' FROM '.MAIN_DB_PREFIX . 'element_element';
-        $sql .= ' WHERE fk_target = ' . $this->id;
-        $sql .= " AND targettype = '" . $this->table_element . "'";
-
-        $resql = $this->db->query($sql);
-        if ($resql) {
-            $nbObjectsLinked = 0;
-            $num = $this->db->num_rows($resql);
-            $i = 0;
-            while ($i < $num) {
-                $nbObjectsLinked++;
-                $i++;
-            }
-            if ($nbObjectsLinked > 0) {
-                return -1;
-            } else {
-                return 1;
-            }
-        } else {
-            dol_print_error($this->db);
-            return -1;
-        }
-    }
-
-    /**
      * Clone an object into another one
      *
      * @param  User      $user    User that creates


### PR DESCRIPTION
Closes #2502

## Problème

La massaction **Supprimer** des listes questionnaires et contrôles ne supprimait jamais rien : `nbok=0`, `nbignored=N`, avec les messages jnotify « Aucun enregistrement supprimé » + « Impossible de supprimer l'enregistrement car il possède des enregistrements fils. » (jnotify disparaît au bout de 3 s → impression que le bouton ne fait rien).

`core/actions_massactions.inc.php` saute chaque ligne dont `is_erasable()` retourne `<= 0`. `Survey::is_erasable()` et `Control::is_erasable()` déléguaient à `isLinkedToOtherObjects()`, qui retourne `-1` dès qu'une ligne existe dans `element_element` avec l'objet en `fk_target`.

Ce lien est celui vers l'élément d'origine (produit, ticket, tiers…), créé à chaque création — donc quasiment tous les objets étaient bloqués. Sur une base de test : 990/1006 questionnaires et 112/112 contrôles.

## Correctif

Suppression des deux overrides `is_erasable()` / `isLinkedToOtherObjects()` sur `Survey` et `Control`. Ils n'avaient aucun autre appelant : leur seul effet était de bloquer la massaction, alors que la suppression depuis la fiche appelait directement `delete()` (`core/actions_addupdatedelete.inc.php`).

Les garde-fous de `Sheet` (trame utilisée par des contrôles), `Question` et `QuestionGroup` (élément réutilisé dans une trame) sont conservés : ceux-là vérifient une vraie réutilisation.

## Tests

Testé sur Dolibarr 23.0.3, liste des questionnaires, sélection de 2 lignes → Supprimer → Valider :

| | Avant | Après |
|---|---|---|
| Message | Aucun enregistrement supprimé + « possède des enregistrements fils » | **2 enregistrement(s) supprimé(s)** |
| `nbok` / `nbignored` | 0 / 2 | 2 / 0 |

Suppression depuis la fiche : inchangée. `php -l` OK sur les deux fichiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)