### PR TITLE
#2507 [Survey] fix: colonnes éléments liés vides et tri sans effet

### DIFF
--- a/class/actions_digiquali.class.php
+++ b/class/actions_digiquali.class.php
@@ -329,12 +329,15 @@ class ActionsDigiquali
     /**
      * Overloading the saturnePrintFieldListLoopObject function : replacing the parent's function with the one below
      *
-     * @param  array $parameters Hook metadata (context, etc...)
-     * @return int               0 < on error, 0 on success, 1 to replace standard code
+     * @param  array       $parameters Hook metadata (context, etc...)
+     * @param  object|null $object     Current object
+     * @return int                     0 < on error, 0 on success, 1 to replace standard code
      * @throws Exception
      */
-    public function printFieldListSelect(array $parameters): int
+    public function printFieldListSelect(array $parameters, ?object $object = null): int
     {
+        global $sortfield, $sortorder;
+
         if (preg_match('/\bsheetlist\b/', $parameters['context'])) {
             $sql = ',COUNT(ee.fk_target) AS nb_question';
             $this->resprints = $sql;
@@ -345,7 +348,86 @@ class ActionsDigiquali
             $this->resprints = $sql;
         }
 
+        if (preg_match('/surveylist|controllist/', $parameters['context']) && $object instanceof CommonObject) {
+            $this->resprints .= $this->getLinkedElementSortSelect($object, (string) $sortfield, (string) $sortorder);
+        }
+
         return 0; // or return 1 to replace standard code
+    }
+
+    /**
+     * Build the SELECT expressions that let a control / survey list be sorted on a linked element column.
+     *
+     * Those columns (contract, project, product, etc.) hold values coming from llx_element_element, not
+     * from the listed object's own table, so ordering on them requires a correlated subquery returning
+     * the linked object's name. Two aliases are produced per sorted column:
+     *  - sortvalue_<post_name> the linked object name, the actual sort criteria
+     *  - sortempty_<post_name> a flag keeping the rows without any linked element at the bottom
+     * They are deliberately prefixed: an alias named after the field itself would land in $object-><key>
+     * through setVarsFromFetchObj and feed a ref string to a column declared as integer:<Class>.
+     * The flag polarity follows the requested direction, because the generic list applies one and the
+     * same direction to every sort token: sorting "is empty" ascending, or "is not empty" descending,
+     * both push the empty rows last.
+     *
+     * The expressions are emitted only for the column currently sorted on, so a list displayed without
+     * sorting on a linked element keeps exactly the query it had before.
+     *
+     * @param  CommonObject $object    Listed object (control or survey)
+     * @param  string       $sortfield Requested sort field(s), comma separated
+     * @param  string       $sortorder Requested sort order(s), comma separated
+     * @return string                  SQL to append to the SELECT, empty when no linked element is sorted on
+     * @throws Exception
+     */
+    protected function getLinkedElementSortSelect(CommonObject $object, string $sortfield, string $sortorder): string
+    {
+        global $conf;
+
+        if (empty($sortfield)) {
+            return '';
+        }
+
+        if (!isset($conf->cache['objectsMetadata']) || empty($conf->cache['objectsMetadata'])) {
+            require_once __DIR__ . '/../../saturne/lib/object.lib.php';
+            $conf->cache['objectsMetadata'] = saturne_get_objects_metadata();
+        }
+
+        $sortedFields = array_map('trim', explode(',', $sortfield));
+        // The direction is repeated for every token by saturne_get_title_field_of_list, so the first one
+        // is the direction the empty flag will be sorted with
+        $isDescending = (bool) preg_match('/^desc/i', trim((string) (explode(',', $sortorder)[0] ?? '')));
+
+        $out      = '';
+        $rendered = [];
+        foreach ($conf->cache['objectsMetadata'] as $objectMetadata) {
+            if ($objectMetadata['conf'] == 0 || !in_array('sortvalue_' . $objectMetadata['post_name'], $sortedFields, true)) {
+                continue;
+            }
+            if (empty($objectMetadata['table_element']) || empty($objectMetadata['name_field'])) {
+                continue;
+            }
+            // 'contrat' is registered as an alias of 'contract' and carries the same post_name
+            if (isset($rendered[$objectMetadata['post_name']])) {
+                continue;
+            }
+            $rendered[$objectMetadata['post_name']] = 1;
+
+            $nameFields = array_map('trim', explode(',', $objectMetadata['name_field']));
+            $nameSelect = count($nameFields) > 1
+                ? 'CONCAT_WS(\' \', lnk.' . implode(', lnk.', $nameFields) . ')'
+                : 'lnk.' . $nameFields[0];
+
+            $subQuery  = '(SELECT ' . $nameSelect . ' FROM ' . $this->db->prefix() . $objectMetadata['table_element'] . ' AS lnk';
+            $subQuery .= ' INNER JOIN ' . $this->db->prefix() . 'element_element AS eesort ON (eesort.fk_source = lnk.rowid)';
+            $subQuery .= ' WHERE eesort.fk_target = t.rowid';
+            $subQuery .= ' AND eesort.targettype = \'' . $this->db->escape($object->module . '_' . $object->element) . '\'';
+            $subQuery .= ' AND eesort.sourcetype = \'' . $this->db->escape($objectMetadata['link_name']) . '\'';
+            $subQuery .= ' ORDER BY ' . $nameSelect . ' LIMIT 1)';
+
+            $out .= ', ' . $subQuery . ' AS sortvalue_' . $objectMetadata['post_name'];
+            $out .= ', (' . $subQuery . ($isDescending ? ' IS NOT NULL' : ' IS NULL') . ') AS sortempty_' . $objectMetadata['post_name'];
+        }
+
+        return $out;
     }
 
     /**
@@ -886,7 +968,9 @@ class ActionsDigiquali
             $sheet     = new Sheet($this->db);
 
             $object->fetchLines();
-            $object->fetchObjectLinked('', '', $object->id, 'digiquali_control');
+            // This hook serves both the control and the survey list, so the target type must follow the
+            // current object: a hard-coded 'digiquali_control' finds no link at all for a survey
+            $object->fetchObjectLinked('', '', $object->id, 'digiquali_' . $object->element);
 
             // A failed fetch() leaves the object as it was, so an unfetched sheet must not reach the cache
             if ($sheet->fetch($object->fk_sheet) > 0) {
@@ -977,16 +1061,24 @@ class ActionsDigiquali
                 $out[$parameters['key']] = isset($conf->cache['sheet']) ? $conf->cache['sheet']->getNomUrl(1, '', 0, 'maxwidth200onsmartphone maxwidth300', -1, 1) : '';
             }
 
-            if (!empty($object->linkedObjects)) {
-                $linkedObjectType = key($object->linkedObjects);
-                $objectsMetadata  = $conf->cache['objectsMetadata'];
+            // Linked element columns (contract, project, product, etc.) are fed by llx_element_element.
+            // Every linked type must be scanned: an object linked to both a contract and a project has
+            // to fill both columns, not only the one of the first type returned by fetchObjectLinked()
+            $objectsMetadata = $conf->cache['objectsMetadata'] ?? [];
+            if (!empty($object->linkedObjects) && is_array($objectsMetadata)) {
                 foreach ($objectsMetadata as $objectMetadata) {
-                    if ($objectMetadata['conf'] == 0 || $objectMetadata['link_name'] != $linkedObjectType) {
+                    if ($objectMetadata['conf'] == 0 || $parameters['key'] != $objectMetadata['post_name']) {
                         continue;
                     }
-                    if ($parameters['key'] == $objectMetadata['post_name']) {
-                        $out[$parameters['key']] = $object->linkedObjects[$objectMetadata['link_name']][key($object->linkedObjects[$objectMetadata['link_name']])]->getNomUrl(1);
+                    $linkedObjects = $object->linkedObjects[$objectMetadata['link_name']] ?? [];
+                    if (empty($linkedObjects)) {
+                        continue;
                     }
+                    $links = [];
+                    foreach ($linkedObjects as $linkedObject) {
+                        $links[] = $linkedObject->getNomUrl(1);
+                    }
+                    $out[$parameters['key']] = implode('<br>', $links);
                 }
             }
 

--- a/view/control/control_list.php
+++ b/view/control/control_list.php
@@ -110,13 +110,16 @@ foreach($objectsMetadata as $objectMetadata) {
 
     if (empty($fromType) || $fromType == $objectMetadata['link_name']) {
         $object->fields[$objectMetadata['post_name']] = [
-            'type'        => 'integer:' . $objectMetadata['class_name'] . ':' . $objectMetadata['class_path'],
-            'label'       => $langs->trans($objectMetadata['langs']),
-            'enabled'     => 1,
-            'position'    => $objectPosition,
-            'visible'     => 2,
-            'csslist'     => 'minwidth150 maxwidth200',
-            'disablesort' => 1
+            'type'       => 'integer:' . $objectMetadata['class_name'] . ':' . $objectMetadata['class_path'],
+            'label'      => $langs->trans($objectMetadata['langs']),
+            'enabled'    => 1,
+            'position'   => $objectPosition,
+            'visible'    => 2,
+            'csslist'    => 'minwidth150 maxwidth200',
+            // Sort on the aliases the printFieldListSelect hook builds from llx_element_element, not on a
+            // t.<key> column that does not exist. The empty flag comes first so the controls without any
+            // linked element stay at the bottom in both directions
+            'otheralias' => 'sortempty_' . $objectMetadata['post_name'] . ',sortvalue_'
         ];
 
         $objectPosition++;
@@ -138,11 +141,16 @@ if (is_array($signatoriesInDictionary) && !empty($signatoriesInDictionary)) {
     }
 }
 
+// Computed columns are built by the saturnePrintFieldListLoopObject hook, not selected from the control
+// table, so they must declare disablesort: the invalid-sortfield guard of
+// objectfields_list_build_sql_select would silently discard the ORDER BY they advertise.
+// days_remaining_before_next_control is the exception: printFieldListSelect adds it as a real SELECT
+// alias, and its empty otheralias makes the title sort on that alias instead of t.<key>
 $object->fields['days_remaining_before_next_control'] = ['label' => 'DaysBeforeNextControl',      'enabled' => 1, 'position' => 66,  'visible' => 2, 'csslist' => 'center', 'otheralias' => ''];
-$object->fields['question_answered']                  = ['label' => 'QuestionAnswered',           'enabled' => 1, 'position' => 66,  'visible' => 2, 'css' => 'center minwidth200 maxwidth250 widthcentpercentminusxx'];
-$object->fields['last_status_date']                   = ['label' => 'LastStatusDate',             'enabled' => 1, 'position' => 67,  'visible' => 2, 'css' => 'center minwidth200 maxwidth300 widthcentpercentminusxx'];
-$object->fields['society_attendants']                 = ['label' => 'SocietyAttendants',          'enabled' => 1, 'position' => 115, 'visible' => 2, 'css' => 'minwidth300 maxwidth500 widthcentpercentminusxx', 'disablesort' => 1];
-$object->fields['average_percentage_questions']       = ['label' => 'AveragePercentageQuestions', 'enabled' => 1, 'position' => 220, 'visible' => 2, 'css' => 'center minwidth200 maxwidth250 widthcentpercentminusxx'];
+$object->fields['question_answered']                  = ['label' => 'QuestionAnswered',           'enabled' => 1, 'position' => 66,  'visible' => 2, 'css' => 'center minwidth200 maxwidth250 widthcentpercentminusxx', 'disablesort' => 1];
+$object->fields['last_status_date']                   = ['label' => 'LastStatusDate',             'enabled' => 1, 'position' => 67,  'visible' => 2, 'css' => 'center minwidth200 maxwidth300 widthcentpercentminusxx', 'disablesort' => 1];
+$object->fields['society_attendants']                 = ['label' => 'SocietyAttendants',          'enabled' => 1, 'position' => 115, 'visible' => 2, 'css' => 'minwidth300 maxwidth500 widthcentpercentminusxx',        'disablesort' => 1];
+$object->fields['average_percentage_questions']       = ['label' => 'AveragePercentageQuestions', 'enabled' => 1, 'position' => 220, 'visible' => 2, 'css' => 'center minwidth200 maxwidth250 widthcentpercentminusxx', 'disablesort' => 1];
 
 $excludeFields = array_merge($excludeFields, ['days_remaining_before_next_control', 'question_answered', 'last_status_date', 'society_attendants', 'average_percentage_questions']);
 

--- a/view/survey/survey_list.php
+++ b/view/survey/survey_list.php
@@ -96,10 +96,11 @@ if (!$sortorder) {
 }
 
 // Definition of custom fields for columns
-$nbLinkableElements = 0;
-$objectPosition     = 21;
-$excludeFields      = [];
-$objectsMetadata    = saturne_get_objects_metadata();
+$nbLinkableElements             = 0;
+$objectPosition                 = 21;
+$excludeFields                  = [];
+$objectsMetadata                = saturne_get_objects_metadata();
+$conf->cache['objectsMetadata'] = $objectsMetadata; // Read back by the saturnePrintFieldListLoopObject hook to render the linked element columns
 foreach($objectsMetadata as $objectMetadata) {
     if ($objectMetadata['conf'] == 0) {
         continue;
@@ -107,14 +108,17 @@ foreach($objectsMetadata as $objectMetadata) {
 
     if (empty($fromType) || $fromType == $objectMetadata['link_name']) {
         $object->fields[$objectMetadata['post_name']] = [
-            'type'        => 'integer:' . $objectMetadata['class_name'] . ':' . $objectMetadata['class_path'],
-            'label'       => $langs->trans($objectMetadata['langs']),
-            'enabled'     => 1,
-            'position'    => $objectPosition,
-            'visible'     => 2,
-            'disablesort' => 1
+            'type'       => 'integer:' . $objectMetadata['class_name'] . ':' . $objectMetadata['class_path'],
+            'label'      => $langs->trans($objectMetadata['langs']),
+            'enabled'    => 1,
+            'position'   => $objectPosition,
+            'visible'    => 2,
+            'csslist'    => 'minwidth150 maxwidth200',
+            // Sort on the aliases the printFieldListSelect hook builds from llx_element_element, not on a
+            // t.<key> column that does not exist. The empty flag comes first so the surveys without any
+            // linked element stay at the bottom in both directions
+            'otheralias' => 'sortempty_' . $objectMetadata['post_name'] . ',sortvalue_'
         ];
-        //@TODO minwidth100 maxwidth125 widthcentpercentminusxx css
 
         $objectPosition++;
         $nbLinkableElements++;
@@ -127,16 +131,21 @@ $conf->cache['signatoriesInDictionary'] = $signatoriesInDictionary;
 if (is_array($signatoriesInDictionary) && !empty($signatoriesInDictionary)) {
     $customFieldsPosition = 111;
     foreach ($signatoriesInDictionary as $signatoryInDictionary) {
-        $object->fields[$signatoryInDictionary->ref] = ['label' => $signatoryInDictionary->ref, 'enabled' => 1, 'position' => $customFieldsPosition++, 'visible' => 2, 'css' => 'minwidth300 maxwidth500 widthcentpercentminusxx right'];
+        // Signatory role columns are computed from the signatures, they have no t.<ref> column in the
+        // survey table: offering a sort link would let saturne silently drop the ORDER BY (disablesort)
+        $object->fields[$signatoryInDictionary->ref] = ['label' => $signatoryInDictionary->ref, 'enabled' => 1, 'position' => $customFieldsPosition++, 'visible' => 2, 'css' => 'minwidth300 maxwidth500 widthcentpercentminusxx right', 'disablesort' => 1];
         $excludeFields[]                             = $signatoryInDictionary->ref;
     }
 }
 
-$object->fields['question_answered']            = ['label' => 'QuestionAnswered',           'enabled' => 1, 'position' => 66,  'visible' => 2, 'css' => 'center minwidth200 maxwidth250 widthcentpercentminusxx'];
-$object->fields['last_status_date']             = ['label' => 'LastStatusDate',             'enabled' => 1, 'position' => 67,  'visible' => 2, 'css' => 'center minwidth200 maxwidth300 widthcentpercentminusxx'];
-$object->fields['society_attendants']           = ['label' => 'SocietyAttendants',          'enabled' => 1, 'position' => 115, 'visible' => 2, 'css' => 'minwidth300 maxwidth500 widthcentpercentminusxx'];
-$object->fields['average_percentage_questions'] = ['label' => 'AveragePercentageQuestions', 'enabled' => 1, 'position' => 220, 'visible' => 2, 'css' => 'center minwidth200 maxwidth250 widthcentpercentminusxx'];
-$object->fields['verdict_object']               = ['label' => 'VerdictObject',              'enabled' => 1, 'position' => 200, 'visible' => 2, 'css' => 'center minwidth200 maxwidth250 widthcentpercentminusxx'];
+// Computed columns: their value is built by the saturnePrintFieldListLoopObject hook, not selected from
+// the survey table. They must declare disablesort, otherwise the title offers a sort link that the
+// invalid-sortfield guard of objectfields_list_build_sql_select silently discards
+$object->fields['question_answered']            = ['label' => 'QuestionAnswered',           'enabled' => 1, 'position' => 66,  'visible' => 2, 'css' => 'center minwidth200 maxwidth250 widthcentpercentminusxx', 'disablesort' => 1];
+$object->fields['last_status_date']             = ['label' => 'LastStatusDate',             'enabled' => 1, 'position' => 67,  'visible' => 2, 'css' => 'center minwidth200 maxwidth300 widthcentpercentminusxx', 'disablesort' => 1];
+$object->fields['society_attendants']           = ['label' => 'SocietyAttendants',          'enabled' => 1, 'position' => 115, 'visible' => 2, 'css' => 'minwidth300 maxwidth500 widthcentpercentminusxx',        'disablesort' => 1];
+$object->fields['average_percentage_questions'] = ['label' => 'AveragePercentageQuestions', 'enabled' => 1, 'position' => 220, 'visible' => 2, 'css' => 'center minwidth200 maxwidth250 widthcentpercentminusxx', 'disablesort' => 1];
+$object->fields['verdict_object']               = ['label' => 'VerdictObject',              'enabled' => 1, 'position' => 200, 'visible' => 2, 'css' => 'center minwidth200 maxwidth250 widthcentpercentminusxx', 'disablesort' => 1];
 
 $excludeFields = array_merge($excludeFields, ['question_answered', 'last_status_date', 'society_attendants', 'average_percentage_questions', 'verdict_object']);
 


### PR DESCRIPTION
Closes #2507

## Ce qui était cassé

Sur la liste des questionnaires, la colonne **Contrat** et toutes les colonnes « éléments liés » restaient vides alors que `llx_element_element` contient bien les liens (1014 `contrat -> digiquali_survey` sur notre base de test). Et sur les deux listes, cliquer sur certaines colonnes ne triait rien.

## Corrections

**1. Type de lien codé en dur** — `saturneSetVarsFromFetchObj` sert les deux listes mais appelait `fetchObjectLinked()` avec `targettype = 'digiquali_control'`. Pour un questionnaire, aucun lien n'était trouvé. Le type suit désormais l'objet courant.

**2. Cache metadata** — `survey_list.php` ne renseignait pas `$conf->cache['objectsMetadata']`, que le hook de rendu relit (`control_list.php` le faisait déjà).

**3. Un seul type lié rendu** — le hook ne traitait que `key($object->linkedObjects)`. Il parcourt maintenant tous les types, donc chaque colonne se remplit indépendamment. Visible sur la liste des contrôles : une ligne affiche à présent son Lot/Série **et** son Projet.

**4. Tri des colonnes éléments liés** — ces valeurs ne sont pas dans la table de l'objet, le tri passe donc par une sous-requête corrélée sur `element_element`, émise par `printFieldListSelect` **uniquement quand on trie sur la colonne** : une liste affichée normalement conserve exactement la requête d'avant. Sous-requête et non JOIN, pour écarter tout risque de multiplication de lignes.

Les lignes sans lien sont rejetées en fin de liste dans les deux sens. Comme la liste générique applique une seule direction à tous les critères de tri, la polarité du drapeau « est vide » suit la direction demandée (`IS NULL` en ASC, `IS NOT NULL` en DESC). Le lien à deux critères passe par `otheralias`, sans modification de saturne — `saturne_get_title_field_of_list` gère nativement le multi-critères.

Les alias sont préfixés (`sortvalue_`, `sortempty_`) : nommés comme le champ, ils atterrissaient dans `$object-><key>` via `setVarsFromFetchObj` et injectaient une référence texte dans une colonne déclarée `integer:<Class>`.

**5. Tri fantôme des colonnes calculées** — elles annonçaient un tri sur un `t.<clé>` inexistant ; la garde anti-`DB_ERROR_NOSUCHFIELD` de saturne supprimait alors l'`ORDER BY` sans rien dire. Elles déclarent maintenant `disablesort`, comme `society_attendants` et les rôles signataires le faisaient déjà. `days_remaining_before_next_control` reste triable : `printFieldListSelect` l'ajoute comme véritable alias SELECT.

## Vérifications

Testé sur les deux listes avec Playwright, base `dolibarr_22_evarisk` (996 questionnaires, 94 contrôles) :

| Contrôle | Résultat |
|---|---|
| Colonne Contrat (questionnaires) | `CT2602-0517`, `CT2510-0400`, `CT2408-0303`… — vide avant |
| Tri Contrat asc / desc | `CT2303-0130 → CT2402-0244` / `CT2602-0517 → CT2602-0516` |
| Tri Lot/Série asc / desc (contrôles) | `5YJ3E7EB4LF571062 → FH272JB` / `TROUSSE-0001 → CLA235115548` |
| Lignes vides en tête de tri | 0/8 dans les deux sens |
| Total de lignes | 996 sans tri comme avec — pas de duplication |
| Colonnes calculées annonçant un tri | aucune |
| Erreurs SQL / warnings PHP | aucune, `php_error.log` non alimenté |
| `php -l` | OK sur les 3 fichiers |

**Performance** : la sous-requête de tri coûte **30 ms, identiques dans les deux sens** (`SHOW PROFILES`). La page en tri croissant est plus lente que la décroissante, mais c'est pré-existant et sans rapport : le test témoin `t.date_creation ASC` — vraie colonne, aucune sous-requête — donne 4759 ms contre 1623 ms en DESC. Le coût est le rendu par ligne des fiches anciennes, non traité ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)