### PR TITLE
#2511 [List] perf: charger les dernières dates de statut d'une page en une requête

### DIFF
--- a/class/actions_digiquali.class.php
+++ b/class/actions_digiquali.class.php
@@ -431,6 +431,99 @@ class ActionsDigiquali
     }
 
     /**
+     * Return the ids of the objects the generic list is about to display.
+     *
+     * $sqlForList is the snapshot the saturne list exposes for aggregate hooks: the whole filtered query,
+     * before sorting and pagination. Wrapping it as a subquery, with the very order and limit the list
+     * applies, yields exactly the rows of the current page - including when the sort references an alias
+     * that only exists inside that query.
+     *
+     * @return int[] Ids of the page, empty when the list variables are out of reach
+     */
+    protected function getListPageObjectIds(): array
+    {
+        global $limit, $offset, $sortfield, $sortorder, $sqlForList;
+
+        if (empty($sqlForList)) {
+            return [];
+        }
+
+        $sql  = 'SELECT listpage.rowid FROM (' . $sqlForList;
+        $sql .= $this->db->order($sortfield, $sortorder);
+        $sql .= (!empty($limit) ? $this->db->plimit($limit + 1, $offset) : '');
+        $sql .= ') AS listpage';
+
+        $resql = $this->db->query($sql);
+        if (!$resql) {
+            return [];
+        }
+
+        $ids = [];
+        while ($obj = $this->db->fetch_object($resql)) {
+            $ids[] = (int) $obj->rowid;
+        }
+        $this->db->free($resql);
+
+        return $ids;
+    }
+
+    /**
+     * Load, for a whole page of listed objects, the date of the last agenda event of each status change.
+     *
+     * The last_status_date column used to call ActionComm::getActions() once per status and per row, so
+     * one hundred queries for a page of twenty-five. Each of them orders by datep and takes the first
+     * row, and MySQL resolves part of them with an index_merge intersection on idx_actioncomm_entity -
+     * an index every row matches - which costs 30ms instead of 0.3ms. One query scoped to the ids of the
+     * page replaces them all and always uses idx_actioncomm_fk_element.
+     *
+     * Rows are read in ascending datep order and each one overwrites the previous entry of its key, so
+     * the value kept is the one of the greatest datep: the same record getActions() returned.
+     *
+     * @param  CommonObject $object Listed object (control or survey), giving the agenda element type
+     * @param  int[]        $ids    Ids to load
+     * @return array<int, array<string, int>> Timestamps indexed by object id, then by agenda code
+     */
+    protected function loadLastStatusDates(CommonObject $object, array $ids): array
+    {
+        $ids = array_filter(array_map('intval', $ids));
+        if (empty($ids)) {
+            return [];
+        }
+
+        $codes = [];
+        foreach (['VALIDATE', 'UNVALIDATE', 'LOCK', 'ARCHIVE'] as $code) {
+            $codes[] = '\'AC_' . dol_strtoupper($object->element) . '_' . $code . '\'';
+        }
+
+        $sql  = 'SELECT fk_element, code, datec FROM ' . $this->db->prefix() . 'actioncomm';
+        $sql .= ' WHERE entity IN (' . getEntity('agenda') . ')';
+        $sql .= ' AND elementtype = \'' . $this->db->escape($object->element . '@' . $object->module) . '\'';
+        $sql .= ' AND code IN (' . implode(', ', $codes) . ')';
+        $sql .= ' AND fk_element IN (' . implode(', ', $ids) . ')';
+        $sql .= ' ORDER BY datep ASC';
+
+        $resql = $this->db->query($sql);
+        if (!$resql) {
+            return [];
+        }
+
+        $lastStatusDates = [];
+        while ($obj = $this->db->fetch_object($resql)) {
+            $lastStatusDates[(int) $obj->fk_element][$obj->code] = $this->db->jdate($obj->datec);
+        }
+        $this->db->free($resql);
+
+        // Ids without any agenda event must still count as loaded, otherwise the caller reloads them one by one
+        foreach ($ids as $id) {
+            if (!isset($lastStatusDates[$id])) {
+                $lastStatusDates[$id] = [];
+            }
+        }
+
+        return $lastStatusDates;
+    }
+
+    /**
      * Overloading the printFieldListFrom function : replacing the parent's function with the one below
      *
      * @param  array       $parameters Hook metadata (context, etc...)
@@ -1114,15 +1207,20 @@ class ActionsDigiquali
             }
 
             if ($parameters['key'] == 'last_status_date') {
-                require_once DOL_DOCUMENT_ROOT . '/comm/action/class/actioncomm.class.php';
-
-                $actionComm = new ActionComm($this->db);
+                if (!isset($conf->cache['lastStatusDatesIds'])) {
+                    $conf->cache['lastStatusDatesIds'] = $this->getListPageObjectIds();
+                    $conf->cache['lastStatusDates']    = $this->loadLastStatusDates($object, $conf->cache['lastStatusDatesIds']);
+                }
+                if (!in_array($object->id, $conf->cache['lastStatusDatesIds'], true)) {
+                    // The page ids could not be determined, so load this row alone rather than show nothing
+                    $conf->cache['lastStatusDatesIds'][] = $object->id;
+                    $conf->cache['lastStatusDates']     += $this->loadLastStatusDates($object, [$object->id]);
+                }
 
                 $out[$parameters['key']] = '';
                 $actionCommCode          = ['VALIDATE' => 'ValidationDate', 'UNVALIDATE' => 'ReopeningDate', 'LOCK' => 'LockingDate', 'ARCHIVE' => 'ArchivingDate'];
                 foreach ($actionCommCode as $code => $date) {
-                    $lastAction     = $actionComm->getActions(0, $object->id, $object->element . '@' . $object->module, ' AND a.code = "AC_' . dol_strtoupper($object->element) . '_' . $code . '"', 'a.datep', 'DESC', 1);
-                    $lastActionDate = (!empty($lastAction) && isset($lastAction[0]->datec)) ? $lastAction[0]->datec : 0;
+                    $lastActionDate = $conf->cache['lastStatusDates'][$object->id]['AC_' . dol_strtoupper($object->element) . '_' . $code] ?? 0;
                     if ($lastActionDate > 0) {
                         $out[$parameters['key']] .= $langs->trans($date) . '<br>' . dol_print_date($lastActionDate, 'dayhour') . '<br>';
                     }


### PR DESCRIPTION
Closes #2511

## Cause racine

La colonne **Dernières dates de statut** appelait `ActionComm::getActions()` quatre fois par ligne, soit 100 requêtes pour une page de 25.

Le nombre d'appels n'est pas ce qui coûte — il est identique sur une page rapide et sur une page lente. C'est le **plan choisi par MySQL** :

| `fk_element` | Plan | Temps |
|---|---|---|
| 2 (brouillon ancien) | `index_merge intersect(idx_actioncomm_fk_element, idx_actioncomm_entity)` | 30,77 ms |
| 1036 (validé récent) | `ref` sur `idx_actioncomm_fk_element` | 0,36 ms |

L'optimiseur intersecte avec `idx_actioncomm_entity`, index que **toutes** les lignes de la table satisfont : 85× plus lent. Grouper les quatre codes en une seule requête ne change pas le plan (testé, 27,7 ms sur l'id pathologique).

Le plan relève de l'optimiseur et d'une table du coeur, donc hors de notre portée — mais le N+1, lui, est de notre côté. Une requête par page le rend sans objet.

## Correctif

Une seule requête, portée sur les ids de la page : `fk_element IN (…)` emprunte alors systématiquement `idx_actioncomm_fk_element`. Mesuré à **5,5 ms**, contre 146 ms pour la variante « tout le type d'élément » (qui balaie la table faute d'index sur `elementtype`).

Les ids viennent de `$sqlForList`, l'instantané que la liste saturne expose explicitement pour les hooks d'agrégat, ré-enveloppé avec l'ordre et la limite appliqués par la liste. **Envelopper plutôt que réécrire le SELECT** est délibéré : ça reste valide quand le tri porte sur un alias qui n'existe qu'à l'intérieur de cette requête, ce qui est le cas des colonnes éléments liés. Si ces variables sont hors de portée, la ligne est chargée seule plutôt que rendue vide silencieusement.

Les lignes sont lues en `datep` croissant et chacune écrase l'entrée précédente de sa clé : la valeur conservée est celle du `datep` maximum, exactement l'enregistrement que renvoyait `getActions()`.

## Mesures

Base `dolibarr_22_evarisk`, comptage par `performance_schema.events_statements_summary_by_digest` remis à zéro avant chaque chargement.

| Page | Avant | Après |
|---|---|---|
| Questionnaires, tri croissant | 5061 ms — 106 req `actioncomm` / **2999 ms** | 2064 ms — **1 req / 4,2 ms** |
| Questionnaires, tri décroissant | 1584 ms — 106 req / 15,3 ms | 1566 ms — 1 req / 0,9 ms |
| Questionnaires, page 2 | 1613 ms — 114 req / 18,3 ms | 1507 ms — 1 req / 0,8 ms |
| Contrôles, tri décroissant | 3852 ms — 148 req / **2441 ms** | 1446 ms — 1 req / 3,3 ms |

SQL cumulé sur les questionnaires en tri croissant : **3208 ms → 214 ms**.

La liste des contrôles était concernée elle aussi (2,7× plus rapide) : son tri par défaut masquait le problème.

## Non-régression

Contenu **rendu** de la colonne comparé ligne à ligne, ancien code contre nouveau, sur quatre pages (deux sens de tri, une deuxième page, les deux listes) : **100 lignes dont 27 non vides, aucun écart**. Valeur type conservée à l'identique : `SY2603-0135 → « Date de validation 29/07/2026 09:40 »`.

Cas limite vérifié séparément : tri sur la colonne Contrat, donc `ORDER BY` sur les alias internes — 1 requête `actioncomm`, aucune erreur SQL, colonne correctement rendue.

`php -l` OK, aucun warning PHP côté web.

## Reste à faire, hors périmètre

528 à 573 requêtes par page subsistent sur `llx_digiquali_question` et ses extrafields (les questions du modèle, refetchées à chaque ligne). Elles sont rapides — 57 ms cumulées — donc le gain porterait sur le temps PHP, pas SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)