### PR TITLE
fix: Add missing translations for object linking toggles (#2517)

### DIFF
--- a/langs/en_US/digiquali.lang
+++ b/langs/en_US/digiquali.lang
@@ -39,4 +39,12 @@ ObtainedScore=Obtained score
 Result=Result
 DefaultValue=Default value
 
+LinkProject_task=Enable link with project tasks
+LinkProject_taskDescription=Allows linking between project tasks and templates
+LinkContrat=Enable link with contracts
+LinkContratDescription=Allows linking between contracts and templates
+LinkCall_list=Enable link with calls
+LinkCall_listDescription=Allows linking between call lists and templates
+
+
 

--- a/langs/fr_FR/digiquali.lang
+++ b/langs/fr_FR/digiquali.lang
@@ -723,4 +723,12 @@ ObtainedScore=Score obtenu
 Result=Résultat
 DefaultValue=Valeur par défaut
 
+LinkProject_task=Activer le lien avec les tâches du projet
+LinkProject_taskDescription=Permet la liaison entre les tâches de projet et les modèles
+LinkContrat=Activer le lien avec les contrats
+LinkContratDescription=Permet la liaison entre les contrats et les modèles
+LinkCall_list=Activer le lien avec les appels
+LinkCall_listDescription=Permet la liaison entre les listes d'appels et les modèles
+
+
 


### PR DESCRIPTION
Resolves #2517%0A%0AAdded missing translation keys for LinkProject_task, LinkContrat, and LinkCall_list in both r_FR and en_US.