### PR TITLE
fix: Fiabilisation du nommage et de l'import/export des archives ZIP (#2519)

### DIFF
--- a/view/digiqualitools.php
+++ b/view/digiqualitools.php
@@ -232,7 +232,7 @@ if (GETPOST('dataMigrationImportZip', 'alpha') && $permissionToWrite) {
             }
 
             $digiqualiExportArray = null;
-            $jsonFileName = '';
+            $jsonString = '';
             if ($result > 0) {
                 $zip    = new ZipArchive;
                 $zipRes = $zip->open($fileDir . $safeZipName);
@@ -241,7 +241,7 @@ if (GETPOST('dataMigrationImportZip', 'alpha') && $permissionToWrite) {
                     for ($i = 0; $i < $zip->numFiles; $i++) {
                         $stat = $zip->statIndex($i);
                         if (preg_match('/\.json$/i', $stat['name'])) {
-                            $jsonFileName = $stat['name'];
+                            $jsonString = $zip->getFromIndex($i);
                             break;
                         }
                     }
@@ -251,10 +251,8 @@ if (GETPOST('dataMigrationImportZip', 'alpha') && $permissionToWrite) {
                     $dqLog('Impossible d\'ouvrir l\'archive ZIP "' . $safeZipName . '" (code ' . $zipRes . ')', 'error');
                 }
 
-                $fileName = !empty($jsonFileName) ? $jsonFileName : preg_replace('/\.zip$/i', '.json', $safeZipName);
-                if (dol_is_file($fileDir . $fileName)) {
-                    $json                 = file_get_contents($fileDir . $fileName);
-                    $digiqualiExportArray = json_decode($json, true);
+                if (!empty($jsonString)) {
+                    $digiqualiExportArray = json_decode($jsonString, true);
                     if (!is_array($digiqualiExportArray)) {
                         $digiqualiExportArray = null;
                         $dqLog('Fichier JSON illisible ou invalide (' . json_last_error_msg() . ')', 'error');

--- a/view/digiqualitools.php
+++ b/view/digiqualitools.php
@@ -232,18 +232,26 @@ if (GETPOST('dataMigrationImportZip', 'alpha') && $permissionToWrite) {
             }
 
             $digiqualiExportArray = null;
+            $jsonFileName = '';
             if ($result > 0) {
                 $zip    = new ZipArchive;
                 $zipRes = $zip->open($fileDir . $safeZipName);
                 if ($zipRes === true) {
                     $zip->extractTo($fileDir);
+                    for ($i = 0; $i < $zip->numFiles; $i++) {
+                        $stat = $zip->statIndex($i);
+                        if (preg_match('/\.json$/i', $stat['name'])) {
+                            $jsonFileName = $stat['name'];
+                            break;
+                        }
+                    }
                     $zip->close();
                     $dqLog('Archive ZIP extraite', 'success');
                 } else {
                     $dqLog('Impossible d\'ouvrir l\'archive ZIP "' . $safeZipName . '" (code ' . $zipRes . ')', 'error');
                 }
 
-                $fileName = preg_replace('/\.zip$/i', '.json', $safeZipName);
+                $fileName = !empty($jsonFileName) ? $jsonFileName : preg_replace('/\.zip$/i', '.json', $safeZipName);
                 if (dol_is_file($fileDir . $fileName)) {
                     $json                 = file_get_contents($fileDir . $fileName);
                     $digiqualiExportArray = json_decode($json, true);

--- a/view/sheet/sheet_export.php
+++ b/view/sheet/sheet_export.php
@@ -182,7 +182,10 @@ if (empty($resHook)) {
         }
 
         $fileDir    = $upload_dir . '/temp/';
-        $exportName = str_replace(' ', '_', (!empty($object->label) ? $object->label : $object->ref));
+        $exportName = (!empty($object->label) ? $object->label : $object->ref);
+        $exportName = dol_string_unaccent($exportName);
+        $exportName = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $exportName);
+        $exportName = preg_replace('/_+/', '_', $exportName);
         $fileName   = dol_sanitizeFileName(dol_print_date(dol_now(), 'dayhourlog', 'tzuser') . '_' . dol_strtolower($exportName) . '_export');
         $fullName   = $fileDir . $fileName . '.json';
 


### PR DESCRIPTION
Résout l'issue #2519

Cette Pull Request apporte deux corrections majeures pour fiabiliser le mécanisme d'import/export des données :

1. **Nettoyage strict du nom de fichier à l'export** :
Le nom du modèle exporté est désormais nettoyé de ses accents et de tout caractère non standard (tiret long, parenthèses, slash, etc.) qui sont remplacés par des tirets bas `_`. Cela évite la création de fichiers ZIP avec des caractères Unicode imprévisibles selon le système de fichiers.

2. **Recherche dynamique du fichier JSON à l'import** :
Lorsqu'un fichier ZIP est uploadé dans Dolibarr, la plateforme lui préfixe automatiquement un horodatage. Le script d'import cherchait naïvement un fichier `.json` portant ce nom modifié à l'intérieur de l'archive (où le fichier a pourtant conservé son nom d'origine). De plus, l'extraction ZIP native (`extractTo`) peut discrètement altérer certains caractères Unicode à l'écriture sur le disque (ex: Windows transforme `–` en `-`), rendant la lecture impossible ensuite. 
Pour résoudre ces problèmes, l'import lit désormais le contenu du fichier JSON directement en mémoire depuis le flux de l'archive (`ZipArchive::getFromIndex`), de façon dynamique et sans dépendre du système de fichiers ou du nom exact.
