### PR TITLE
#2521 [Control] fix: guard linked object reads when its module is disabled

### DIFF
--- a/class/control.class.php
+++ b/class/control.class.php
@@ -475,8 +475,11 @@ class Control extends SaturneObject
 
         $qcFrequency = 0;
         $this->fetchObjectLinked('', '', '', $this->module . '_' . $this->element);
-        $linkedObjectType = key($this->linkedObjects);
-        $linkedObject     = current($this->linkedObjects[$linkedObjectType]);
+
+        // linkedObjects is empty when the control has no link, or when the linked object belongs to a
+        // module that has been disabled since : fetchObjectLinked() silently drops those types.
+        $linkedObjectType = !empty($this->linkedObjects) ? key($this->linkedObjects) : '';
+        $linkedObject     = !empty($linkedObjectType) ? current($this->linkedObjects[$linkedObjectType]) : null;
         if ($this->verdict == 1 && !empty($linkedObject->array_options['options_qc_frequency'])) {
             $qcFrequency = $linkedObject->array_options['options_qc_frequency'];
         } elseif ($this->verdict == 2) {
@@ -491,7 +494,8 @@ class Control extends SaturneObject
             }
         }
 
-        if (!empty($this->next_control_date)) {
+        // The reminder is about the linked object : without one there is nothing to remind about.
+        if (!empty($this->next_control_date) && !empty($linkedObject)) {
             // Get object metadata infos on current linked object
             $objectMetadataInfos = [];
             $objectsMetadata     = saturne_get_objects_metadata();
@@ -1137,10 +1141,23 @@ class Control extends SaturneObject
             require_once __DIR__ . '/sheet.class.php';
 
             $objectsMetadata = saturne_get_objects_metadata();
+
+            // linkedObjects is keyed by link_name, the metadata by object type : they differ for
+            // thirdparty/societe, contact/socpeople and task/project_task, hence this lookup table.
+            $metadataByLinkName = [];
+            foreach ($objectsMetadata as $objectMetadata) {
+                if (!empty($objectMetadata['link_name'])) {
+                    $metadataByLinkName[$objectMetadata['link_name']] = $objectMetadata;
+                }
+            }
+
             foreach ($controls as $control) {
                 $control->fetchObjectLinked('', '', $control->id, 'digiquali_control');
-                $linkedObjectType = key($control->linkedObjects);
-                if (!isset($control->linkedObjects) && $objectsMetadata[$linkedObjectType]['conf'] < 0) {
+
+                // A control with no link, or whose linked object belongs to a disabled module, has
+                // nothing to show in the LinkedObject column : skip it instead of dereferencing null.
+                $linkedObjectType = !empty($control->linkedObjects) ? key($control->linkedObjects) : '';
+                if (empty($linkedObjectType) || empty($metadataByLinkName[$linkedObjectType]['conf'])) {
                     continue;
                 }
 

--- a/lib/digiquali_control.lib.php
+++ b/lib/digiquali_control.lib.php
@@ -343,8 +343,18 @@ function get_parent_linked_object_qc_frequency(CommonObject $linkedObject, array
         $objectsMetadata = saturne_get_objects_metadata();
     }
 
-    $qcFrequency    = 0;
-    $objectMetadata = $objectsMetadata[$linkedObject->element];
+    $qcFrequency = 0;
+
+    // $linkedObject->element holds the link name, the metadata is keyed by object type : they differ
+    // for thirdparty/societe, contact/socpeople and task/project_task, hence this lookup.
+    $objectMetadata = [];
+    foreach ($objectsMetadata as $objectsMetadataEntry) {
+        if (($objectsMetadataEntry['link_name'] ?? '') === $linkedObject->element) {
+            $objectMetadata = $objectsMetadataEntry;
+            break;
+        }
+    }
+
     if (isset($objectMetadata['fk_parent'])) {
         $parentLinkedObject = null;
         foreach ($objectsMetadata as $objectMetadata) {

--- a/view/control/control_card.php
+++ b/view/control/control_card.php
@@ -672,7 +672,9 @@ if ($object->id > 0 && (empty($action) || ($action != 'create'))) {
     $questionsAndGroups = $sheet->fetchQuestionsAndGroups();
     $object->fetchObjectLinked('', '', $object->id, 'digiquali_control');
 
-    $linkedObjectType = key($object->linkedObjects);
+    // linkedObjects is empty when the control has no link, or when the linked object belongs to a
+    // module that has been disabled since : fetchObjectLinked() silently drops those types.
+    $linkedObjectType = !empty($object->linkedObjects) ? key($object->linkedObjects) : '';
 
     // Build the full list of question IDs of the sheet, including questions nested inside (sub-)groups.
     // fetchAllQuestions() walks the question groups recursively, so deeply nested questions are counted too.
@@ -756,11 +758,16 @@ if ($object->id > 0 && (empty($action) || ($action != 'create'))) {
     // Clone confirmation
     if (($action == 'clone' && (empty($conf->use_javascript_ajax) || !empty($conf->dol_use_jmobile))) || (!empty($conf->use_javascript_ajax) && empty($conf->dol_use_jmobile))) {
         // Define confirmation messages
-        $objectMetadata = $objectsMetadata[$linkedObjectType];
-        $linkedObject   = $object->linkedObjects[$objectMetadata['link_name']][key($object->linkedObjects[$objectMetadata['link_name']])];
+        // Without a loadable linked object the clone label falls back on the control reference.
+        $objectMetadata   = !empty($linkedObjectType) ? ($objectsMetadata[$linkedObjectType] ?? []) : [];
+        $linkedObjectName = $object->ref;
+        if (!empty($objectMetadata['link_name']) && !empty($object->linkedObjects[$objectMetadata['link_name']])) {
+            $linkedObject     = current($object->linkedObjects[$objectMetadata['link_name']]);
+            $linkedObjectName = $linkedObject->{$objectMetadata['name_field']};
+        }
 
         $formQuestionClone = [
-            ['type' => 'text',     'name' => 'clone_label', 'label' => $langs->trans('NewLabelForClone', $langs->transnoentities('The' . ucfirst($object->element))), 'value' => dol_print_date($object->control_date, '%Y%m%d') . '-' . $linkedObject->{$objectMetadata['name_field']}, 'size' => 24],
+            ['type' => 'text',     'name' => 'clone_label', 'label' => $langs->trans('NewLabelForClone', $langs->transnoentities('The' . ucfirst($object->element))), 'value' => dol_print_date($object->control_date, '%Y%m%d') . '-' . $linkedObjectName, 'size' => 24],
             ['type' => 'checkbox', 'name' => 'clone_attendants',         'label' => $langs->trans('CloneAttendants'),        'value' => 1],
             ['type' => 'checkbox', 'name' => 'clone_photos',             'label' => $langs->trans('ClonePhotos'),            'value' => 1],
             ['type' => 'checkbox', 'name' => 'clone_control_equipments', 'label' => $langs->trans('CloneControlEquipments'), 'value' => 1]


### PR DESCRIPTION
Closes #2521

## Problème

`digiqualiindex.php` renvoie une page blanche dès qu'un contrôle du tableau de bord est lié à un objet dont le module a été désactivé — reproduit en désactivant Stocks, ce qui désactive aussi `productbatch` :

```
PHP Fatal error: Uncaught TypeError: key(): Argument #1 ($array) must be of type array, null given
  in class/control.class.php:1165
```

`fetchObjectLinked()` écarte silencieusement les types dont le module est éteint, donc `linkedObjects` revient vide. `key([])` rend `null`, le garde-fou existant ne se déclenche jamais (`!isset()` au lieu de `empty()`, `&&` au lieu de `||`), et la ligne suivante déréférence `linkedObjects[null]`.

Un contrôle **sans aucun objet lié** produit exactement le même effet, sans qu'aucun module ne soit désactivé.

## Correctif

Quatre lectures rendues défensives, toutes sur la même cause :

| Fichier | Zone | Avant | Après |
|---|---|---|---|
| `class/control.class.php` | `getControlListsByNextControl()` | fatal | le contrôle est écarté du tableau de bord |
| `class/control.class.php` | `setLocked()` | `current(null)` | `$linkedObject` à `null`, rappel non créé |
| `view/control/control_card.php` | confirmation de clonage | fatal | libellé replié sur la réf. du contrôle |
| `lib/digiquali_control.lib.php` | `get_parent_linked_object_qc_frequency()` | `Undefined array key "societe"` | résolution par `link_name` |

## Le piège de la clé

`linkedObjects` est indexé par **link_name**, la métadonnée par **type d'objet**. Les deux diffèrent pour `thirdparty`/`societe`, `contact`/`socpeople` et `task`/`project_task`.

Un simple `$objectsMetadata[$linkedObjectType]` fait donc disparaître du tableau de bord les contrôles liés à un tiers — c'est précisément ce que produisait ma première version du correctif, détecté au test. La résolution passe désormais par une table `link_name → métadonnée`.

## Vérification

Module Stocks désactivé, 7 des 10 contrôles du tableau de bord étant liés à un `productlot` :

| Page | Avant | Après |
|---|---|---|
| `digiqualiindex.php` | fatal | 200, 3 contrôles listés |
| fiche contrôle liée à un productlot (id 1, 3) | fatal | 200, aucun warning |
| confirmation de clonage sur ces contrôles | fatal | 200, aucun warning |
| fiche contrôle liée à un tiers (id 2) | warning `societe` | 200, plus de warning |
| liste des contrôles | OK | OK |

Le tableau de bord liste bien `FC2308-0002` (tiers), `FC2309-0007` et `FC2409-0015` (projets) : la non-régression sur les types dont le module est actif est vérifiée.

## Hors périmètre, constaté au passage

- `get_parent_linked_object_qc_frequency()` réutilise `$objectMetadata` comme variable de boucle tout en lisant `$objectMetadata['fk_parent']` : la comparaison porte sur l'entrée elle-même et l'héritage de fréquence parent ne peut pas fonctionner. Non corrigé ici, le comportement resterait à définir.
- `core/tpl/modal/modal_task_timespent_list.tpl.php:42` émet `Undefined array key "timespent"`, sans rapport avec ce correctif.

Indépendant de #2510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)