### PR TITLE
#2523 [UI] fix: always define the timespent key and add the missing deletion error labels

### DIFF
--- a/langs/en_US/digiquali.lang
+++ b/langs/en_US/digiquali.lang
@@ -25,6 +25,10 @@ ControlDocumentPDF                      = Control Sheet PDF with photo
 
 NoDocumentation                         = No linked document
 
+# Deletion errors
+ErrorQuestionUsedInSheet                = Question %s cannot be deleted, it is used in one or more templates.
+ErrorQuestionGroupUsedInSheet           = Question group %s cannot be deleted, it is used in one or more templates.
+
 # Grading Policy
 GradingPolicy = Grading Policy
 Proportional = Proportional

--- a/langs/fr_FR/digiquali.lang
+++ b/langs/fr_FR/digiquali.lang
@@ -123,6 +123,7 @@ NoteControl                   = Note publique
 EnterComment                  = Saisir les commentaires
 EnterCommentTooltip           = Saisit le commentaire sur les réponses de question
 ErrorQuestionUsedInSheet      = La question %s ne peut pas être supprimée, elle est utilisée dans un ou plusieurs modèles.
+ErrorQuestionGroupUsedInSheet = Le groupe de questions %s ne peut pas être supprimé, il est utilisé dans un ou plusieurs modèles.
 ErrorNoQuestionSelected       = Aucune question sélectionnée
 AddQuestionIntoCategory       = Assigner cette catégorie à la question
 QuestionType                  = Type de question

--- a/lib/digiquali_control.lib.php
+++ b/lib/digiquali_control.lib.php
@@ -422,6 +422,9 @@ function get_task_infos(Task $task): array
         $out['task']['time'] = convertSecondToTime($task->timespent_total_duration) . ' / ' . convertSecondToTime($task->planned_workload);
     }
 
+    // Always defined, so that consumers can iterate without checking the key on a task with no time spent
+    $out['task']['timespent'] = [];
+
     $task->fetchTimeSpentOnTask();
     if (is_array($task->lines) && !empty($task->lines)) {
         foreach ($task->lines as $timespent) {


### PR DESCRIPTION
Closes #2523

Relevé par balayage Playwright de 33 pages DigiQuali (admin, listes, fiches, actions), en lisant le `php_error.log` entre deux marqueurs. Deux warnings distincts, plus aucun après correctif.

## 1. `Undefined array key "timespent"`

`core/tpl/modal/modal_task_timespent_list.tpl.php:42`

`get_task_infos()` ne créait `$out['task']['timespent']` que si la tâche portait au moins une ligne de temps passé, alors que le template itère dessus sans garde. Toute tâche sans temps passé déclenchait le warning.

Corrigé à la source plutôt que dans le template : la clé est désormais initialisée à `[]`, de sorte que la structure retournée soit identique quel que soit le contenu et que tout consommateur puisse itérer sans vérifier.

## 2. `Undefined array key "ErrorQuestionGroupUsedInSheet"`

`view/questiongroup/questiongroup_list.php:192`

```php
$langs->tab_translate['ErrorRecordHasChildren'] = $langs->tab_translate['ErrorQuestionGroupUsedInSheet'];
```

La clé n'existait dans aucun fichier de langue. Au-delà du warning, le refus de suppression d'un groupe utilisé dans un modèle affichait donc un message **vide** au lieu d'expliquer la raison.

Ajoutée en `fr_FR` et `en_US`. Au passage `ErrorQuestionUsedInSheet`, qui souffrait du même symptôme côté anglais, n'existait qu'en `fr_FR` : ajoutée en `en_US` également.

## Vérification

Balayage rejoué après correctif sur les mêmes pages : **0 warning, 0 deprecated, 0 notice, 0 fatal**.

Résolution des libellés contrôlée dans les deux langues :

```
fr_FR  ErrorQuestionUsedInSheet       => La question GQ-0001 ne peut pas être supprimée, …
fr_FR  ErrorQuestionGroupUsedInSheet  => Le groupe de questions GQ-0001 ne peut pas être supprimé, …
en_US  ErrorQuestionUsedInSheet       => Question GQ-0001 cannot be deleted, …
en_US  ErrorQuestionGroupUsedInSheet  => Question group GQ-0001 cannot be deleted, …
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)