### PR TITLE
#2525 [Survey] fix: guard missing document and uninitialised user preference

### DIFF
--- a/core/tpl/frontend/digiquali_answers_frontend.tpl.php
+++ b/core/tpl/frontend/digiquali_answers_frontend.tpl.php
@@ -38,7 +38,8 @@ if (is_array($questions) && !empty($questions)) {
             $questionAnswer = $objectLine->answer;
             $comment = $objectLine->comment;
         }
-        if (!$user->conf->DIGIQUALI_SHOW_ONLY_QUESTIONS_WITH_NO_ANSWER or empty($questionAnswer)) {
+        // The user preference does not exist until the toggle has been used at least once
+        if (empty($user->conf->DIGIQUALI_SHOW_ONLY_QUESTIONS_WITH_NO_ANSWER) || empty($questionAnswer)) {
             ?>
             <div class="question table-id-<?php echo $question->id ?> <?php echo ($objectLine->status == Answer::STATUS_VALIDATED && !empty($questionAnswer) ? ' question-complete' : ''); ?>" data-autoSave="<?php echo getDolGlobalInt('DIGIQUALI_' . dol_strtoupper($object->element) . 'DET_AUTO_SAVE_ACTION'); ?>" data-type="<?php echo dol_escape_htmltag($question->type); ?>" data-points="<?php echo (float)$question->points; ?>" data-grading-policy="<?php echo dol_escape_htmltag($question->grading_policy); ?>" data-min="<?php echo dol_escape_htmltag($question->question_answer_min_value); ?>" data-max="<?php echo dol_escape_htmltag($question->question_answer_max_value); ?>" data-correct-answers="<?php echo dol_escape_htmltag($question->correct_answers); ?>">
                 <?php if ($question->show_photo > 0 && getDolGlobalInt('DIGIQUALI_' . dol_strtoupper($object->element) . '_DISPLAY_MEDIAS')) : ?>

--- a/view/survey/survey_card.php
+++ b/view/survey/survey_card.php
@@ -638,9 +638,9 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
             // Send email
             $displayButton = $onPhone ? '<i class="fas fa-envelope fa-2x"></i>' : '<i class="fas fa-envelope"></i>' . ' ' . $langs->trans('SendMail') . ' ';
             if ($object->status != Survey::STATUS_LOCKED) {
+                // dol_most_recent_file() returns null while no document has been generated yet
                 $fileParams = dol_most_recent_file($upload_dir . '/' . $object->element . 'document' . '/' . $object->ref);
-                $file       = $fileParams['fullname'];
-                if (file_exists($file) && !strstr($fileParams['name'], 'specimen')) {
+                if (!empty($fileParams) && file_exists($fileParams['fullname']) && !strstr($fileParams['name'], 'specimen')) {
                     $forceBuildDoc = 0;
                 } else {
                     $forceBuildDoc = 1;
@@ -679,14 +679,17 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
             <div class="progress progress-bar-success" style="width:<?php print ($questionCounter > 0 ? ($answerCounter/$questionCounter) * 100 : 0) . '%'; ?>;" title="<?php print ($questionCounter > 0 ? $answerCounter . '/' . $questionCounter : 0); ?>"></div>
         </div>
         <?php if ($answerCounter != $questionCounter) {
-            print $user->conf->DIGIQUALI_SHOW_ONLY_QUESTIONS_WITH_NO_ANSWER ? img_picto($langs->trans('Enabled'), 'switch_on', 'class="show-only-questions-with-no-answer marginrightonly"') : img_picto($langs->trans('Disabled'), 'switch_off', 'class="show-only-questions-with-no-answer marginrightonly"');
-            print $form->textwithpicto($user->conf->DIGIQUALI_SHOW_ONLY_QUESTIONS_WITH_NO_ANSWER ? '<i class="fas fa-eye"></i>' : '<i class="fas fa-eye-slash"></i>', $langs->trans('ShowOnlyQuestionsWithNoAnswer'));
+            // The user preference does not exist until the toggle has been used at least once
+            $showOnlyWithNoAnswer = !empty($user->conf->DIGIQUALI_SHOW_ONLY_QUESTIONS_WITH_NO_ANSWER);
+
+            print $showOnlyWithNoAnswer ? img_picto($langs->trans('Enabled'), 'switch_on', 'class="show-only-questions-with-no-answer marginrightonly"') : img_picto($langs->trans('Disabled'), 'switch_off', 'class="show-only-questions-with-no-answer marginrightonly"');
+            print $form->textwithpicto($showOnlyWithNoAnswer ? '<i class="fas fa-eye"></i>' : '<i class="fas fa-eye-slash"></i>', $langs->trans('ShowOnlyQuestionsWithNoAnswer'));
         } else {
             $user->conf->DIGIQUALI_SHOW_ONLY_QUESTIONS_WITH_NO_ANSWER = 0;
         } ?>
     </div>
 
-    <?php if (!$user->conf->DIGIQUALI_SHOW_ONLY_QUESTIONS_WITH_NO_ANSWER || $answerCounter != $questionCounter) {
+    <?php if (empty($user->conf->DIGIQUALI_SHOW_ONLY_QUESTIONS_WITH_NO_ANSWER) || $answerCounter != $questionCounter) {
         print load_fiche_titre($langs->transnoentities('LinkedQuestionsList', $questionCounter), '', '');
         print '<div id="tablelines" class="question-answer-container">';
         $questionsAndGroups = $sheet->fetchQuestionsAndGroups();


### PR DESCRIPTION
Closes #2525

## Problème

`view/survey/survey_card.php` émettait quatre warnings :

```
Trying to access array offset on null                                        survey_card.php:642
Undefined property: stdClass::$DIGIQUALI_SHOW_ONLY_QUESTIONS_WITH_NO_ANSWER  survey_card.php:682, 683, 689
```

Les deux causes sont **déjà correctement gardées dans `view/control/control_card.php`** ; la fiche questionnaire n'avait simplement pas suivi.

| | Fiche contrôle (correct) | Fiche questionnaire (avant) |
|---|---|---|
| document | `!empty($fileparams) && file_exists($fileparams['fullname'])` | `$file = $fileParams['fullname'];` |
| préférence | `!empty($user->conf->DIGIQUALI_SHOW_ONLY_…)` | `$user->conf->DIGIQUALI_SHOW_ONLY_…` |

`dol_most_recent_file()` renvoie `null` tant qu'aucun document n'a été généré, et la préférence utilisateur n'existe pas tant que le bouton n'a jamais été actionné.

## Correctif

Alignement sur le motif de la fiche contrôle, plus le même accès non gardé dans `core/tpl/frontend/digiquali_answers_frontend.tpl.php:41` (interface publique).

## Vérification

Page rechargée : **0 warning, 0 fatal**. Le bloc de progression, le compteur de réponses et la liste des questions liées s'affichent à l'identique.

## Constat hors périmètre

Le bouton « afficher seulement les questions sans réponse » de la fiche questionnaire est **inerte** : il est rendu avec `class="show-only-questions-with-no-answer"`, or aucun script ne se lie à cette classe. Le seul gestionnaire (`js/modules/control.js:65`) écoute `[data-toggle-action]`, ce qu'utilise la fiche contrôle :

```php
'data-toggle-action="show_only_questions_with_no_answer" data-toggle-key="show_only_questions_with_no_answer" data-update-targets=".progress-info,.question-answer-container"'
```

L'action serveur correspondante existe pourtant déjà (`survey_card.php:193`) mais n'est jamais atteinte. Défaut antérieur et indépendant de ce correctif : non traité ici pour ne pas activer une fonctionnalité dormante sans validation. À ouvrir séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)