### PR TITLE
#2527 [Survey] fix: make the show-only-unanswered toggle actually work

### DIFF
--- a/class/control.class.php
+++ b/class/control.class.php
@@ -1232,7 +1232,8 @@ class Control extends SaturneObject
      */
     public function displayAnswers(ControlLine $objectLine, array $questionsAndGroups, bool $isFrontend, int $level = 0)
     {
-        global $conf, $langs;
+        // $user is required by the included template, which reads the per-user display preferences
+        global $conf, $langs, $user;
 
         $object = $this;
 

--- a/class/survey.class.php
+++ b/class/survey.class.php
@@ -746,7 +746,8 @@ class Survey extends SaturneObject
      */
     public function displayAnswers(SurveyLine $objectLine, array $questionsAndGroups, bool $isFrontend = false, int $level = 0)
     {
-        global $conf, $langs;
+        // $user is required by the included template, which reads the per-user display preferences
+        global $conf, $langs, $user;
 
         $object = $this;
 

--- a/core/tpl/digiquali_answers.tpl.php
+++ b/core/tpl/digiquali_answers.tpl.php
@@ -70,6 +70,12 @@ foreach ($questionsAndGroups as $questionOrGroup) {
         if (is_array($groupQuestions) && !empty($groupQuestions)) {
             print '<div class="group-questions">';
             foreach ($groupQuestions as $question) {
+                // Reset on every iteration : without this an unanswered question inherits the answer
+                // and the comment of the previous one, which both displays them and hides the question
+                // from the "only questions with no answer" filter
+                $questionAnswer = '';
+                $comment        = '';
+
                 $tmpObjectLine = new $objectLineClass($object->db);
                 $result = $tmpObjectLine->fetchFromParentWithQuestion($object->id, $question->id);
                 if (is_array($result) && !empty($result)) {

--- a/view/survey/survey_card.php
+++ b/view/survey/survey_card.php
@@ -191,13 +191,12 @@ if (empty($resHook)) {
     }
 
     if ($action == 'show_only_questions_with_no_answer') {
+        // saturne.utils.toggleSetting() posts {<data-toggle-key>: value}, so the key is the action name
         $data = json_decode(file_get_contents('php://input'), true);
-
-        $showOnlyQuestionsWithNoAnswer = $data['showOnlyQuestionsWithNoAnswer'];
-
-        $tabParam['DIGIQUALI_SHOW_ONLY_QUESTIONS_WITH_NO_ANSWER'] = $showOnlyQuestionsWithNoAnswer;
-
-        dol_set_user_param($db, $conf, $user, $tabParam);
+        if (isset($data[$action])) {
+            $tabParam['DIGIQUALI_' . dol_strtoupper($action)] = $data[$action];
+            dol_set_user_param($db, $conf, $user, $tabParam);
+        }
     }
 
     require_once __DIR__ . '/../../core/tpl/digiquali_answers_save_action.tpl.php';
@@ -682,8 +681,14 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
             // The user preference does not exist until the toggle has been used at least once
             $showOnlyWithNoAnswer = !empty($user->conf->DIGIQUALI_SHOW_ONLY_QUESTIONS_WITH_NO_ANSWER);
 
-            print $showOnlyWithNoAnswer ? img_picto($langs->trans('Enabled'), 'switch_on', 'class="show-only-questions-with-no-answer marginrightonly"') : img_picto($langs->trans('Disabled'), 'switch_off', 'class="show-only-questions-with-no-answer marginrightonly"');
-            print $form->textwithpicto($showOnlyWithNoAnswer ? '<i class="fas fa-eye"></i>' : '<i class="fas fa-eye-slash"></i>', $langs->trans('ShowOnlyQuestionsWithNoAnswer'));
+            // The generic handler of control.js binds on data-toggle-action, not on a class
+            $toggleAttributes  = 'data-toggle-action="show_only_questions_with_no_answer"';
+            $toggleAttributes .= ' data-toggle-key="show_only_questions_with_no_answer"';
+            $toggleAttributes .= ' data-update-targets=".progress-info,.question-answer-container"';
+            $toggleAttributes .= ' class="show-only-questions-with-no-answer marginrightonly"';
+
+            print img_picto($langs->trans($showOnlyWithNoAnswer ? 'Enabled' : 'Disabled'), $showOnlyWithNoAnswer ? 'switch_on' : 'switch_off', $toggleAttributes);
+            print $form->textwithpicto($showOnlyWithNoAnswer ? '<i class="fas fa-eye"></i>' : '<i class="fas fa-eye-slash"></i>', $langs->trans('ShowOnlyQuestionsWithNoAnswer'), 1, 'help', 'marginrightonly');
         } else {
             $user->conf->DIGIQUALI_SHOW_ONLY_QUESTIONS_WITH_NO_ANSWER = 0;
         } ?>


### PR DESCRIPTION
Closes #2527

Le bouton « afficher seulement les questions sans réponse » de la fiche questionnaire ne faisait rien. Le diagnostic a révélé **trois défauts en cascade** : chacun seul suffisait à rendre la fonctionnalité inopérante.

## 1. Le bouton n'était lié à aucun script

Il était rendu avec `class="show-only-questions-with-no-answer"`, or le seul gestionnaire (`js/modules/control.js:65`) écoute `[data-toggle-action]`. Aucun clic n'était jamais capté.

Corrigé en reprenant les attributs de la fiche contrôle : `data-toggle-action`, `data-toggle-key` et `data-update-targets`.

## 2. L'action serveur attendait une clé que le client n'envoie jamais

`saturne.utils.toggleSetting(action, dataKey)` poste `{<data-toggle-key>: valeur}`, donc en snake_case :

| | Clé lue | Compatible |
|---|---|---|
| `control_card.php` | `$data[$action]` → `show_only_questions_with_no_answer` | oui |
| `survey_card.php` (avant) | `$data['showOnlyQuestionsWithNoAnswer']` | non |

Même branchée, l'action aurait enregistré `null`. Alignée sur la lecture générique de la fiche contrôle.

## 3. Le template ne voyait pas la préférence — y compris sur la fiche contrôle

`Survey::displayAnswers()` et `Control::displayAnswers()` déclarent `global $conf, $langs;` **sans `$user`**, puis incluent `core/tpl/digiquali_answers.tpl.php`. Dans le template, `$user` était donc indéfini, `isset($user->conf->DIGIQUALI_SHOW_ONLY_QUESTIONS_WITH_NO_ANSWER)` toujours faux, et la garde laissait passer **toutes** les questions.

Conséquence : le filtre était inopérant **aussi sur la fiche contrôle**, où le bouton bascule pourtant correctement. Le défaut y était simplement invisible.

## Bonus : fuite de réponse et de commentaire entre questions

Dans la boucle des questions d'un groupe, `$questionAnswer` et `$comment` n'étaient affectés que dans la branche `if`, jamais réinitialisés dans le `else`. Une question sans réponse héritait donc de la réponse **et du commentaire de la question précédente** — un commentaire s'affichait sur une question à laquelle il n'appartient pas, indépendamment de tout filtre.

La boucle de premier niveau réinitialise bien à chaque tour (ligne 40), pas la boucle imbriquée.

## Vérification

| Questionnaire | Badge | Sans filtre | Avec filtre |
|---|---|---|---|
| 852 | 2/9 | 9 questions | **7** |
| 491 | 7/9 | 9 questions | **2** |

L'appel réseau part bien avec la bonne clé (`POST {"show_only_questions_with_no_answer":1}`), l'état persiste après rechargement (`fa-toggle-on`) et se restaure. Aucun warning, aucune erreur JS.

Sur une fiche contrôle complète (13/13), le bouton reste masqué : comportement voulu, il n'apparaît que si des questions restent sans réponse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)