### PR TITLE
#2529 [Control] fix: PHP warnings and double escaped group description

### DIFF
--- a/class/actions_digiquali.class.php
+++ b/class/actions_digiquali.class.php
@@ -800,7 +800,7 @@ class ActionsDigiquali
                             $linkedMedias    = 0;
                             $confName        = 'DIGIQUALI_' . dol_strtoupper($object->element) . '_USE_LARGE_MEDIA_IN_GALLERY';
 
-                            if (is_array($questionsLinked['digiquali_question']) && !empty($questionsLinked['digiquali_question'])) {
+                            if (!empty($questionsLinked['digiquali_question']) && is_array($questionsLinked['digiquali_question'])) {
                                 foreach ($questionsLinked['digiquali_question'] as $questionLinked) {
                                     if ($questionLinked->authorize_answer_photo > 0) {
                                         saturne_show_medias_linked('digiquali', $conf->digiquali->multidir_output[$conf->entity] . '/' . $object->element . '/' . $object->ref . '/answer_photo/' . $questionLinked->ref, (getDolGlobalInt($confName) ? 'large' : 'medium'), '', 0, 0, 0, 200, 200, 0, 0, 0, $object->element . '/' . $object->ref . '/answer_photo/' . $questionLinked->ref, $object, '', 0, 0);

--- a/class/questiongroup.class.php
+++ b/class/questiongroup.class.php
@@ -752,6 +752,7 @@ class QuestionGroup extends SaturneObject
         $numberOfQuestions = 0;
         $questionGroupTotalPoints = 0;
         $questionGroupCorrectAnswersTotalPoints = 0;
+        $atLeastOneIncorrectSubGroup = false;
 
         $this->fetchObjectLinked($this->id, 'digiquali_questiongroup');
 

--- a/core/tpl/digiquali_answers.tpl.php
+++ b/core/tpl/digiquali_answers.tpl.php
@@ -28,6 +28,10 @@
  * Variables : $permissionToAddTask, $permissionToReadTask
  */
 
+// Nesting depth of the question groups. Set by Control/Survey::displayAnswers(),
+// but the template is also included directly from the card pages
+$level = $level ?? 0;
+
 foreach ($questionsAndGroups as $questionOrGroup) {
     if (!isset($objectLineClass) && is_object($objectLine)) {
         $objectLineClass = get_class($objectLine);
@@ -59,7 +63,9 @@ foreach ($questionsAndGroups as $questionOrGroup) {
         print '<div class="digiquali-question-group' . $isGroupCorrectCssClass . '" id="'. $questionGroup->id .'" ' .$groupCssStyles. '>';
         print '<h3>' . img_picto('', $questionGroup->picto) . '&nbsp; ' . htmlspecialchars($questionGroup->label) . ' <span class="badge badge-info group-answer-counter" data-group-id="' . $questionGroup->id . '" style="margin-left: 10px;" title="Nombre de questions répondues">' . $numberOfAnsweredQuestions . '/' . $numberOfQuestions . ' réponses aux questions</span></h3>';
         if (!empty($questionGroup->description)) {
-            print '<p class="group-description">' . nl2br(htmlspecialchars($questionGroup->description)) . '</p>';
+            // The description is edited with DolEditor, so it is already stored HTML encoded :
+            // escaping it again turns "l&#39;audit" into a visible "l&#39;audit"
+            print '<p class="group-description">' . dol_htmlentitiesbr($questionGroup->description) . '</p>';
         }
         if ($showCorrection) {
             [$pointsResult, $rateResult] = $questionGroup->getFormattedSuccessPointsAndRates($object);


### PR DESCRIPTION
Closes #2529

## Warnings

| Fichier | Cause |
|---|---|
| `class/questiongroup.class.php` | `$atLeastOneIncorrectSubGroup` n'est affectée que dans la boucle sur les sous-groupes. Un groupe sans sous-groupe atteint le `return` sans qu'elle existe → 1 warning par groupe. |
| `core/tpl/digiquali_answers.tpl.php` | `$level` est un paramètre de `displayAnswers()`, donc présent quand le template est inclus depuis la classe. Mais `control_card.php` l'inclut directement, sans ce paramètre. Le défaut dans le template couvre les 3 points d'inclusion. |
| `class/actions_digiquali.class.php` | `is_array($x['k']) && !empty($x['k'])` évalue l'accès au tableau avant le test d'existence. Les deux tests sont simplement inversés. |

Aucun changement de comportement : `null` et `false` sont tous deux falsy dans les tests concernés, et le badge Medias affiche toujours la même valeur.

## Affichage de la description

La description d'un groupe s'affichait `Tâches à faire avant l&#39;audit`.

Le champ est édité avec `DolEditor`, il est donc stocké déjà encodé en HTML — vérifié en base :

```
QG2602-0006 → "Tâches à faire avant l&#39;audit"
```

Le template appliquait `htmlspecialchars()` par-dessus, ce qui ré-encode le `&`. Remplacé par `dol_htmlentitiesbr()`, qui est déjà ce qu'utilise la fiche groupe de questions (`view/questiongroup/questiongroup_card.php`).

Le `htmlspecialchars()` sur le **label** juste à côté est conservé : contrairement à la description, les labels stockent bien l'apostrophe brute (`L'activité des différents domaines techniques`), l'échappement y est donc nécessaire.

## Test

Fiche contrôle `FC2602-0054` (id 112), 7 groupes de questions :

- avant : 9 warnings dans `php_error.log` par chargement, description affichée `Tâches à faire avant l&#39;audit`
- après : 0 warning, description affichée `Tâches à faire avant l'audit`

Vérifié par rechargement de la page et lecture du DOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)