### PR TITLE
#2531 [Sheet] fix: PHP warnings on the statistics tab and on model creation

### DIFF
--- a/view/sheet/sheet_card.php
+++ b/view/sheet/sheet_card.php
@@ -261,6 +261,9 @@ if (empty($reshook)) {
 		$object->element_linked = json_encode($showArray);
 
 		$object->default_control_tags = json_encode(GETPOST('default_control_tags', 'array'));
+		// The generic add/update include re-reads this 'text' field with GETPOST(..., 'nohtml'),
+		// which warns on the array posted by the multiselect : hand it the encoded value
+		$_POST['default_control_tags'] = $object->default_control_tags;
 		$_POST['show_project'] = GETPOST('ctrl_show_project');
 		$_POST['show_tags'] = GETPOST('ctrl_show_tags');
 
@@ -286,6 +289,9 @@ if (empty($reshook)) {
 		$object->element_linked = json_encode($showArray);
 
 		$object->default_control_tags = json_encode(GETPOST('default_control_tags', 'array'));
+		// The generic add/update include re-reads this 'text' field with GETPOST(..., 'nohtml'),
+		// which warns on the array posted by the multiselect : hand it the encoded value
+		$_POST['default_control_tags'] = $object->default_control_tags;
 		$_POST['show_project'] = GETPOST('ctrl_show_project');
 		$_POST['show_tags'] = GETPOST('ctrl_show_tags');
 

--- a/view/sheet/sheet_stats.php
+++ b/view/sheet/sheet_stats.php
@@ -135,7 +135,9 @@ if (!empty($questions) && !empty($controls)) {
             $possibleAnswers = $answer->fetchAll('ASC', 'position', 0, 0,  ['customsql' => 't.status > ' . Answer::STATUS_DELETED . ' AND t.fk_question = ' . $question->id]);
             if (!empty($possibleAnswers)) {
                 foreach ($possibleAnswers as $possibleAnswer) {
-                    $questionAnswerStats[$question->id][$possibleAnswer->id] = [
+                    // Object lines store the answer position, not the answer id, and every reader
+                    // of $questionAnswerStats below indexes it by position : seed it the same way
+                    $questionAnswerStats[$question->id][$possibleAnswer->position] = [
                         'nb_answers' => 0,
                     ];
                 }
@@ -156,8 +158,11 @@ if (!empty($questions) && !empty($controls)) {
             $questionLinked = new Question($db);
             $questionLinked->fetch($controlAnswer->fk_question);
             if (in_array($questionLinked->type, ['UniqueChoice', 'OkKo', 'OkKoToFixNonApplicable', 'MultipleChoices'])) {
-                if ($controlAnswer->answer > 0) {
-                    $questionAnswerStats[$controlAnswer->fk_question][$controlAnswer->answer]['nb_answers'] += 1;
+                // MultipleChoices stores every selected position in a single comma separated string
+                foreach (explode(',', (string) $controlAnswer->answer) as $answerPosition) {
+                    if ($answerPosition > 0 && isset($questionAnswerStats[$controlAnswer->fk_question][$answerPosition])) {
+                        $questionAnswerStats[$controlAnswer->fk_question][$answerPosition]['nb_answers'] += 1;
+                    }
                 }
             } else if ($questionLinked->type == 'Percentage') {
                 $questionAnswerStats[$controlAnswer->fk_question][$i] = [


### PR DESCRIPTION
Closes #2531

## 1. Onglet Statistiques — 50 warnings par chargement

Le tableau `$questionAnswerStats` était amorcé avec les **ids de réponses**, alors que ses trois lecteurs l'indexent par **position** :

- `sheet_stats.php:206` et `:215`
- `Sheet::showAnswerRepartition()` (`class/sheet.class.php:928`)

Les lignes d'objet stockent bien la position, comme `Question::calculateEarnedPoints()` le suppose déjà (`explode(',', $answerValue)`). Vérifié en base :

```
controldet : fk_question=257  answer='1'
answer     : id=674 pos=1 OK | 675 pos=2 KO | 676 pos=3 A réparer | 677 pos=4 NA
```

Les cases amorcées restaient donc à zéro et l'incrément en créait d'autres à la volée — d'où les warnings.

Second point sur la même boucle : **MultipleChoices** stocke toutes les positions sélectionnées dans une seule chaîne (`'1,2'`, `'1,2,3'` présents en base). L'incrément créait une case `"1,2"` qu'aucun lecteur n'affiche, mais qui entrait dans `$totalAnswers` et faussait tous les pourcentages de la question. La chaîne est maintenant découpée, et le `isset()` ignore une position dont la réponse a été supprimée.

## 2. Création d'un modèle sans libellé

Reproduction : `sheet_card.php?action=create`, remplir tous les champs sauf le libellé, envoyer.

```
dol_html_entity_decode        <- reçoit un array (3 éléments)
dol_string_nohtmltag
sanitizeVal
actions_addupdatedelete.inc.php:129   GETPOST($key, 'nohtml')
sheet_card.php:392                    include
```

Le multiselect poste `default_control_tags[]`, mais le champ est déclaré `'type' => 'text'` : l'include générique le relit avec `GETPOST($key, 'nohtml')`, dont le cas dans `sanitizeVal` n'est pas protégé contre les tableaux (contrairement à `'alphanohtml'` juste à côté).

Corrigé côté module en suivant l'idiome déjà utilisé deux lignes plus bas (`$_POST['show_project'] = ...`). L'include générique reçoit maintenant la valeur JSON déjà encodée, au lieu de réassigner au champ un tableau converti en chaîne qui écrasait le `json_encode()` du module.

Le JSON traverse `dol_string_nohtmltag()` intact, vérifié sur les trois formes :

```
[]                    -> []                    identique
["352","370","277"]   -> ["352","370","277"]   identique
[352,370,277]         -> [352,370,277]         identique
```

## Tests

- onglet Statistiques des modèles 46, 47, 49, 50, 51, 52 : **50 → 0 warning**, pourcentages inchangés et cohérents avec les données brutes (somme à 100 % par question)
- création sans libellé rejouée dans le navigateur : **1 → 0 warning**
- `sheet_card.php` (nu, `?id=`, `action=create`, `action=edit`), `sheet_list.php` et `control_card.php?id=112` : 0 warning
- aucune ligne `default_control_tags` corrompue en base

## Hors périmètre, signalé

`MarqueNF` est amorcé (l.134) mais absent de la liste de comptage (l.158) : ce type afficherait toujours 0 %. Aucune question de ce type en base, donc le changement n'est pas testable ici — laissé en l'état.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
