### PR TITLE
#2535 [Hook] fix: ne plus lire l'objet global absent des listes qui n'en posent pas

### DIFF
--- a/class/actions_digiquali.class.php
+++ b/class/actions_digiquali.class.php
@@ -674,6 +674,11 @@ class ActionsDigiquali
     {
         global $conf, $extrafields, $langs, $object;
 
+        // The hook also runs on the lists that declare no object of their own, and there is nothing to decorate there
+        if (!is_object($object)) {
+            return 0;
+        }
+
         if (!isset($conf->cache['objectsMetadata']) || empty($conf->cache['objectsMetadata'])) {
             require_once __DIR__ . '/../../saturne/lib/object.lib.php';
             $objectsMetadata = saturne_get_objects_metadata();


### PR DESCRIPTION
## Changements

`printFieldListOption` lit la globale `$object` et déréférence `$object->element` dans une boucle sur les métadonnées d'objets. Une liste qui exécute le hook sans instancier d'`$object` global produisait un avertissement PHP par entrée de métadonnées :

```
PHP Warning: Attempt to read property "element" on null in class/actions_digiquali.class.php on line 511
```

Soit 38 avertissements par chargement de page — constaté sur la liste des accidents de Digirisk (`view/accident/accident_list.php`), 114 occurrences dans `php_error.log` pour trois visites.

Le hook sort désormais sans rien faire quand la page hôte ne pose pas d'objet : il n'y a alors aucun libellé d'extrafield (`qc_frequency`, `control_history_link`) à décorer. Comportement inchangé partout où `$object` existe — liste des risques, fiches, etc.

## Fichiers modifiés

- `class/actions_digiquali.class.php`

## Issue

Close #2535
