### PR TITLE
#2544 [List] fix: PHP warnings on list pages

### DIFF
--- a/langs/en_US/digiquali.lang
+++ b/langs/en_US/digiquali.lang
@@ -28,6 +28,7 @@ NoDocumentation                         = No linked document
 # Deletion errors
 ErrorQuestionUsedInSheet                = Question %s cannot be deleted, it is used in one or more templates.
 ErrorQuestionGroupUsedInSheet           = Question group %s cannot be deleted, it is used in one or more templates.
+ErrorSheetUsedInControl                 = Template %s cannot be deleted, it is used in one or more controls/surveys.
 
 # Grading Policy
 GradingPolicy = Grading Policy

--- a/view/controldet/controldet_list.php
+++ b/view/controldet/controldet_list.php
@@ -112,7 +112,7 @@ foreach ($object->fields as $key => $val) {
     if (GETPOST('search_' . $key, 'alpha') !== '') {
         $search[$key] = GETPOST('search_' . $key, 'alpha');
     }
-    if (in_array($val['type'], ['date', 'datetime', 'timestamp'])) {
+    if (isset($val['type']) && in_array($val['type'], ['date', 'datetime', 'timestamp'])) {
         $search[$key . '_dtstart'] = dol_mktime(0, 0, 0, GETPOSTINT('search_' . $key . '_dtstartmonth'), GETPOSTINT('search_' . $key . '_dtstartday'), GETPOSTINT('search_' . $key . '_dtstartyear'));
         $search[$key . '_dtend']   = dol_mktime(23, 59, 59, GETPOSTINT('search_' . $key . '_dtendmonth'), GETPOSTINT('search_' . $key . '_dtendday'), GETPOSTINT('search_' . $key . '_dtendyear'));
     }
@@ -196,7 +196,6 @@ if (empty($resHook)) {
     $objectlabel = 'ControlLine';
     $uploaddir   = $conf->digiquali->dir_output;
 
-    $langs->tab_translate['ErrorRecordHasChildren'] = $langs->tab_translate['ErrorControlLineUsedInSheet'];
     require_once DOL_DOCUMENT_ROOT . '/core/actions_massactions.inc.php';
 
     if (($massaction == 'lock' || ($action == 'lock' && $confirm == 'yes')) && $permissiontoadd) {

--- a/view/question/question_list.php
+++ b/view/question/question_list.php
@@ -105,7 +105,7 @@ foreach ($object->fields as $key => $val) {
     if (GETPOST('search_' . $key, 'alpha') !== '') {
         $search[$key] = GETPOST('search_' . $key, 'alpha');
     }
-    if (in_array($val['type'], ['date', 'datetime', 'timestamp'])) {
+    if (isset($val['type']) && in_array($val['type'], ['date', 'datetime', 'timestamp'])) {
         $search[$key . '_dtstart'] = dol_mktime(0, 0, 0, GETPOSTINT('search_' . $key . '_dtstartmonth'), GETPOSTINT('search_' . $key . '_dtstartday'), GETPOSTINT('search_' . $key . '_dtstartyear'));
         $search[$key . '_dtend']   = dol_mktime(23, 59, 59, GETPOSTINT('search_' . $key . '_dtendmonth'), GETPOSTINT('search_' . $key . '_dtendday'), GETPOSTINT('search_' . $key . '_dtendyear'));
     }

--- a/view/questiongroup/questiongroup_list.php
+++ b/view/questiongroup/questiongroup_list.php
@@ -105,7 +105,7 @@ foreach ($object->fields as $key => $val) {
     if (GETPOST('search_' . $key, 'alpha') !== '') {
         $search[$key] = GETPOST('search_' . $key, 'alpha');
     }
-    if (in_array($val['type'], ['date', 'datetime', 'timestamp'])) {
+    if (isset($val['type']) && in_array($val['type'], ['date', 'datetime', 'timestamp'])) {
         $search[$key . '_dtstart'] = dol_mktime(0, 0, 0, GETPOSTINT('search_' . $key . '_dtstartmonth'), GETPOSTINT('search_' . $key . '_dtstartday'), GETPOSTINT('search_' . $key . '_dtstartyear'));
         $search[$key . '_dtend']   = dol_mktime(23, 59, 59, GETPOSTINT('search_' . $key . '_dtendmonth'), GETPOSTINT('search_' . $key . '_dtendday'), GETPOSTINT('search_' . $key . '_dtendyear'));
     }


### PR DESCRIPTION
Closes #2544

## Clé `type` absente

`controldet_list.php` déclare `question_type` et `tasks` comme colonnes virtuelles — sans clé `'type'`, puisqu'elles ne correspondent à aucune colonne SQL et sont dans `$excludeFields`. La boucle de construction des critères y accédait sans garde, d'où deux warnings à chaque affichage.

`control_list.php` et `sheet_list.php` avaient déjà le `isset()` ; `controldet`, `question` et `questiongroup` ne l'avaient pas. Les trois sont alignés.

## Message d'erreur effacé

```php
$langs->tab_translate['ErrorRecordHasChildren'] = $langs->tab_translate['ErrorControlLineUsedInSheet'];
```

`ErrorControlLineUsedInSheet` n'existe dans aucun fichier de langue. Au-delà du warning, cette ligne **écrasait** le message générique par du vide : une suppression en masse qui échoue n'affichait plus rien du tout. Le copier-coller vient de `question_list.php` où la clé existe — mais une ligne de contrôle n'est pas « utilisée dans un modèle », le message n'aurait pas eu de sens. Suppression de l'affectation, le message générique Dolibarr reprend sa place.

## Parité de langue

`ErrorSheetUsedInControl` n'existait qu'en fr_FR — les utilisateurs anglophones perdaient le message sur `sheet_list.php`. Ajouté en en_US.

## Tests

Les six listes du module rechargées après correction, `php_error.log` surveillé en différentiel :

| Liste | Enregistrements | Warnings |
|---|---|---|
| controldet | 627 | 0 |
| question | 255 | 0 |
| questiongroup | 7 | 0 |
| sheet | 28 | 0 |
| control | 94 | 0 |
| survey | 996 | 0 |

Aucune nouvelle ligne dans `php_error.log`, aucune erreur fatale, `php -l` propre sur les trois fichiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)