### PR TITLE
#2552 [Control] fix: référence de l'action cliquable dans le Gantt

### DIFF
--- a/core/tpl/control/control_actionplan_gantt.tpl.php
+++ b/core/tpl/control/control_actionplan_gantt.tpl.php
@@ -28,6 +28,8 @@
  * Variables  : $actions, $actionPlanUrl, $actionPlanFormParameters (optional), $actionPlanGranularity
  */
 
+$actionPlanPublic = !empty($actionPlanPublic);
+
 $granularities = [
     'day'   => $langs->trans('ActionPlanGanttDay'),
     'week'  => $langs->trans('ActionPlanGanttWeek'),
@@ -145,7 +147,14 @@ if (empty($scheduled)) {
 
         print '<tr>';
         print '<td class="actionplan-gantt-head actionplan-gantt-label">';
-        print '<span class="actionplan-gantt-ref">' . dol_escape_htmltag($actionTask->ref) . (is_object($actionRow['question']) ? ' &middot; ' . dol_escape_htmltag($actionRow['question']->ref) : '') . '</span>';
+        // The action and the question it answers open from here, the way they do from the list. The
+        // public interface keeps them as plain text : it opens with the sole tracking link
+        print '<span class="actionplan-gantt-ref">';
+        print $actionPlanPublic ? dol_escape_htmltag($actionTask->ref) : $actionTask->getNomUrl(1);
+        if (is_object($actionRow['question'])) {
+            print ' &middot; ' . ($actionPlanPublic ? dol_escape_htmltag($actionRow['question']->ref) : $actionRow['question']->getNomUrl(1));
+        }
+        print '</span>';
         print dol_escape_htmltag($actionTask->label);
         print '</td>';
 


### PR DESCRIPTION
## Changements

- Dans la colonne « Action / Description » de la vue Gantt, la référence de l'action ouvre la tâche et celle de la question ouvre la question, comme dans la vue liste du même plan
- L'interface publique les garde en texte brut : elle s'ouvre avec le seul lien de suivi, sans authentification

## Fichiers modifiés

- `core/tpl/control/control_actionplan_gantt.tpl.php`

## Tests

Vérifié dans le navigateur sur les deux interfaces :

| Vue | Liens rendus |
|---|---|
| Onglet | `projet/tasks/task.php?id=1252` et `digiquali/view/question/question_card.php?id=212` |
| Interface publique | aucun, texte brut |

Close #2552
