### PR TITLE
#2554 [Control] fix: barre d'avancement au-dessus de la liste du plan d'action

### DIFF
--- a/core/tpl/control/control_actionplan_list.tpl.php
+++ b/core/tpl/control/control_actionplan_list.tpl.php
@@ -59,6 +59,13 @@ foreach ([
 }
 print '</div>';
 
+// How far the plan has gone, on every action it holds and not only on the filtered ones. It sits with
+// the figures it summarises, which is label enough for a bar carrying its own value
+print '<div class="actionplan-progress">';
+print '<span class="actionplan-progress-bar"><span class="actionplan-progress-done" style="width: ' . $stats['progress'] . '%;"></span></span>';
+print '<span class="actionplan-progress-value">' . $stats['progress'] . '% (' . $stats['done'] . '/' . $stats['total'] . ')</span>';
+print '</div>';
+
 // Filters. A GET form keeps a filtered plan shareable and reloadable, which a POST one would not
 print '<form method="GET" action="' . dol_escape_htmltag($actionPlanUrl) . '" class="actionplan-filters">';
 foreach ($actionPlanFormParameters ?? [] as $parameterKey => $parameterValue) {
@@ -184,13 +191,6 @@ foreach ($actions as $actionRow) {
 }
 
 print '</table>';
-print '</div>';
-
-// How far the plan has gone, on every action it holds and not only on the filtered ones
-print '<div class="actionplan-progress">';
-print '<span class="actionplan-progress-label">' . $langs->trans('ControlActionPlanGlobalProgress') . '</span>';
-print '<span class="actionplan-progress-bar"><span class="actionplan-progress-done" style="width: ' . $stats['progress'] . '%;"></span></span>';
-print '<span class="actionplan-progress-value">' . $stats['progress'] . '% (' . $stats['done'] . '/' . $stats['total'] . ')</span>';
 print '</div>';
 
 print '</div>';

--- a/langs/en_US/digiquali.lang
+++ b/langs/en_US/digiquali.lang
@@ -93,7 +93,6 @@ ActionPlanAssignee            = Assignee
 ActionPlanVerdict             = Verdict
 ActionPlanRowActions          = Actions
 ActionPlanNoAction            = No action in the plan
-ControlActionPlanGlobalProgress      = Overall progress of the action plan:
 ActionPlanOpenTask            = Open the task
 ActionPlanConfirmDeleteAction = Are you sure you want to delete this action?
 ActionPlanViewGantt           = Gantt

--- a/langs/fr_FR/digiquali.lang
+++ b/langs/fr_FR/digiquali.lang
@@ -485,7 +485,6 @@ ActionPlanAssignee                             = Responsable
 ActionPlanVerdict                              = Verdict
 ActionPlanRowActions                           = Actions
 ActionPlanNoAction                             = Aucune action dans le plan
-ControlActionPlanGlobalProgress                       = Avancement global du plan d'action :
 ActionPlanOpenTask                             = Ouvrir la tâche
 ActionPlanConfirmDeleteAction                  = Êtes-vous sûr de vouloir supprimer cette action ?
 ActionPlanViewGantt                            = Gantt


### PR DESCRIPTION
## Changements

- La barre d'avancement global passe sous les compteurs et au-dessus des filtres : elle resume ces compteurs, elle se lit donc avec eux plutot qu'en pied de tableau
- Son intitule est retire, la barre porte deja sa valeur et suit immediatement les compteurs ; la cle de langue devenue inutilisee part avec

## Fichiers modifies

- core/tpl/control/control_actionplan_list.tpl.php
- langs/fr_FR/digiquali.lang, langs/en_US/digiquali.lang

## Tests

Ordre du DOM verifie dans le navigateur, sur l'onglet et sur l'interface publique : compteurs, barre, filtres, tableau.

Close #2554
