### PR TITLE
#2556 [Sheet] fix: valeurs par défaut sur les propriétés typées label et description

### DIFF
--- a/class/sheet.class.php
+++ b/class/sheet.class.php
@@ -134,7 +134,7 @@ class Sheet extends SaturneObject
     /**
      * @var int ID.
      */
-    public int $rowid;
+    public int $rowid = 0;
 
     /**
      * @var string Ref.
@@ -179,12 +179,12 @@ class Sheet extends SaturneObject
     /**
      * @var string Label.
      */
-    public string $label;
+    public string $label = '';
 
     /**
      * @var string|null Description.
      */
-    public ?string $description;
+    public ?string $description = null;
 
     /**
      * @var int|null Project ID.


### PR DESCRIPTION
Closes #2556

L'aperçu du modèle PDF Fiche de contrôle ouvrait une page blanche : `Sheet::$label` et `Sheet::$description` sont des propriétés typées sans valeur par défaut, donc **non initialisées** (et non `null`) tant que le `fetch()` n'a pas eu lieu. Les lire lève un `Error` fatal sur PHP 8.

`pdf_controldocument.modules.php` tombe dessus depuis la page Documents, où le spécimen n'a pas de `fk_sheet` — mais tout consommateur qui lit une fiche sans vérifier que son `fetch()` a réussi était exposé au même fatal.

Les mêmes valeurs par défaut que les autres propriétés typées de la classe sont ajoutées ; `rowid` reçoit aussi son `= 0`.

## Tests

Sur Dolibarr 23 : l'aperçu du modèle Fiche de contrôle renvoie `200 application/pdf` et la page s'affiche correctement (en-tête, synthèse, tableaux équipements / contacts / contrôleurs). Aucun warning PHP sur la page Documents de DigiQuali.

Le reste du bug (résolution de la classe document, redirection vers le spécimen, objet spécimen vide) est corrigé par Evarisk/Saturne#1521, déjà mergée — sans elle l'aperçu échoue plus tôt (`Class "Productlot" not found`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)