### PR TITLE
#2560 [Onglets] fix: fatal error on the control and survey tabs of linked objects

### DIFF
--- a/lib/digiquali_linked_object.lib.php
+++ b/lib/digiquali_linked_object.lib.php
@@ -35,6 +35,32 @@ define('DIGIQUALI_LINKED_OBJECT_EXCLUDED_PREFIX', 'digiquali_');
 define('DIGIQUALI_LINKED_OBJECT_ELEMENT_TYPES', 'digiquali_control,digiquali_survey');
 
 /**
+ * Get the metadata of an object from its element link name
+ *
+ * Tabs and links carry the link name of the element (fromtype=commande), which is not always the key the
+ * metadata array is indexed with (order) : reading the array with it lands on a missing entry, and every
+ * consumer of the result then works on null.
+ *
+ * @param  array<string, array<string, mixed>> $objectsMetadata Result of saturne_get_objects_metadata()
+ * @param  string                              $linkName        Element link name, ex. 'commande'
+ * @return array<string, mixed>                                 Matching metadata | empty array if none matches
+ */
+function digiquali_get_object_metadata_from_link_name(array $objectsMetadata, string $linkName): array
+{
+    if (empty($linkName)) {
+        return [];
+    }
+
+    foreach ($objectsMetadata as $objectMetadata) {
+        if (($objectMetadata['link_name'] ?? '') == $linkName) {
+            return $objectMetadata;
+        }
+    }
+
+    return [];
+}
+
+/**
  * Get the extrafield definitions carried by DigiQuali linked objects
  *
  * @return array Definitions accepted by saturne_sync_linked_object_extrafields()

--- a/view/control/control_card.php
+++ b/view/control/control_card.php
@@ -56,6 +56,7 @@ require_once __DIR__ . '/../../class/digiqualidocuments/controldocument.class.ph
 require_once __DIR__ . '/../../lib/digiquali_control.lib.php';
 require_once __DIR__ . '/../../lib/digiquali_answer.lib.php';
 require_once __DIR__ . '/../../lib/digiquali_sheet.lib.php';
+require_once __DIR__ . '/../../lib/digiquali_linked_object.lib.php';
 
 if (isModEnabled('dolicar')) {
     require_once __DIR__ . '/../../../dolicar/class/registrationcertificatefr.class.php';
@@ -666,7 +667,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'create'))) {
     if (($action == 'clone' && (empty($conf->use_javascript_ajax) || !empty($conf->dol_use_jmobile))) || (!empty($conf->use_javascript_ajax) && empty($conf->dol_use_jmobile))) {
         // Define confirmation messages
         // Without a loadable linked object the clone label falls back on the control reference.
-        $objectMetadata   = !empty($linkedObjectType) ? ($objectsMetadata[$linkedObjectType] ?? []) : [];
+        $objectMetadata   = digiquali_get_object_metadata_from_link_name($objectsMetadata, $linkedObjectType);
         $linkedObjectName = $object->ref;
         if (!empty($objectMetadata['link_name']) && !empty($object->linkedObjects[$objectMetadata['link_name']])) {
             $linkedObject     = current($object->linkedObjects[$objectMetadata['link_name']]);

--- a/view/control/control_list.php
+++ b/view/control/control_list.php
@@ -37,6 +37,7 @@ if (isModEnabled('categorie')) {
 
 // load DigiQuali libraries
 require_once __DIR__ . '/../../class/control.class.php';
+require_once __DIR__ . '/../../lib/digiquali_linked_object.lib.php';
 require_once __DIR__ . '/../../core/boxes/digiqualiwidget1.php';
 
 // Global variables definitions
@@ -103,6 +104,11 @@ $objectPosition                 = 21;
 $excludeFields                  = [];
 $objectsMetadata                = saturne_get_objects_metadata();
 $conf->cache['objectsMetadata'] = $objectsMetadata;
+
+// The tab is opened with the link name of the element (fromtype=commande), which is not always the key the
+// metadata array is indexed with (order) : resolve the entry once instead of reading the array with a key
+// that does not exist. Stays empty for the fromtype values that designate no object, ex. fk_sheet
+$fromObjectMetadata = digiquali_get_object_metadata_from_link_name($objectsMetadata, $fromType);
 foreach($objectsMetadata as $objectMetadata) {
     // conf holds the raw constant value : absent or empty means the link is off. A == 0 test would
     // let those through, since PHP 8 compares '' to 0 as strings
@@ -173,7 +179,9 @@ foreach ($object->fields as $key => $val) {
 }
 
 if (!empty($fromType)) {
-    $search[$objectsMetadata[$fromType]['post_name']] = $fromId;
+    if (!empty($fromObjectMetadata)) {
+        $search[$fromObjectMetadata['post_name']] = $fromId;
+    }
     switch ($fromType) {
         case 'fk_sheet':
             $search['fk_sheet'] = $fromId;
@@ -283,11 +291,15 @@ if ($mode == 'pwa') {
 $title = $langs->trans(ucfirst($object->element) . 'List');
 saturne_header(0,'', $title, $helpUrl ?? '', '', 0, 0, [], [], '', 'mod-' . $object->module . '-' . $object->element . ' page-list bodyforlist');
 
-if (!empty($fromType)) {
-    $objectsMetadata[$fromType]['object']->fetch($fromId);
-    saturne_get_fiche_head($objectsMetadata[$fromType]['object'], $object->element, $langs->trans(ucfirst($object->element)));
-    $linkBack = '<a href="' . dol_buildpath($fromType . '/list.php?restore_lastsearch_values=1', 1) . '">' . $langs->trans('BackToList') . '</a>';
-    saturne_banner_tab($objectsMetadata[$fromType]['object'], 'fromtype=' . $fromType . '&fromid', $linkBack, 1, 'rowid', ($fromType == 'productlot' ? 'batch' : 'ref'));
+if (!empty($fromObjectMetadata)) {
+    $fromObject = $fromObjectMetadata['object'];
+    $fromObject->fetch($fromId);
+    saturne_get_fiche_head($fromObject, $object->element, $langs->trans(ucfirst($object->element)));
+
+    // The list of the element is reached through its own path : fromtype is a link name, not a directory
+    $backUrl  = $fromObjectMetadata['list_url'] ?: $fromType . '/list.php';
+    $linkBack = '<a href="' . dol_buildpath($backUrl . '?restore_lastsearch_values=1', 1) . '">' . $langs->trans('BackToList') . '</a>';
+    saturne_banner_tab($fromObject, 'fromtype=' . $fromType . '&fromid', $linkBack, 1, 'rowid', ($fromType == 'productlot' ? 'batch' : 'ref'));
 
     $moreUrlParameters = '&fromtype=' . $fromType . '&fromid=' . $fromId . '&mode=' . $mode;
 

--- a/view/survey/survey_list.php
+++ b/view/survey/survey_list.php
@@ -37,6 +37,7 @@ if (isModEnabled('categorie')) {
 
 // load DigiQuali libraries
 require_once __DIR__ . '/../../class/survey.class.php';
+require_once __DIR__ . '/../../lib/digiquali_linked_object.lib.php';
 
 // Global variables definitions
 global $conf, $db, $hookmanager, $langs, $user;
@@ -101,6 +102,11 @@ $objectPosition                 = 21;
 $excludeFields                  = [];
 $objectsMetadata                = saturne_get_objects_metadata();
 $conf->cache['objectsMetadata'] = $objectsMetadata; // Read back by the saturnePrintFieldListLoopObject hook to render the linked element columns
+
+// The tab is opened with the link name of the element (fromtype=commande), which is not always the key the
+// metadata array is indexed with (order) : resolve the entry once instead of reading the array with a key
+// that does not exist. Stays empty for the fromtype values that designate no object, ex. fk_sheet
+$fromObjectMetadata = digiquali_get_object_metadata_from_link_name($objectsMetadata, $fromType);
 foreach($objectsMetadata as $objectMetadata) {
     // conf holds the raw constant value : absent or empty means the link is off. A == 0 test would
     // let those through, since PHP 8 compares '' to 0 as strings
@@ -165,7 +171,9 @@ foreach ($object->fields as $key => $val) {
 }
 
 if (!empty($fromType)) {
-    $search[$objectsMetadata[$fromType]['post_name']] = $fromId;
+    if (!empty($fromObjectMetadata)) {
+        $search[$fromObjectMetadata['post_name']] = $fromId;
+    }
     if ($fromType == 'fk_sheet') {
         $search['fk_sheet'] = $fromId;
     }
@@ -265,11 +273,15 @@ if (empty($resHook)) {
 $title = $langs->trans(ucfirst($object->element) . 'List');
 saturne_header(0,'', $title, $helpUrl ?? '', '', 0, 0, [], [], '', 'mod-' . $object->module . '-' . $object->element . ' page-list bodyforlist');
 
-if (!empty($fromType) && !empty($fromId)) {
-    $objectsMetadata[$fromType]['object']->fetch($fromId);
-    saturne_get_fiche_head($objectsMetadata[$fromType]['object'], $object->element, $langs->trans(ucfirst($object->element)));
-    $linkBack = '<a href="' . dol_buildpath($fromType . '/list.php?restore_lastsearch_values=1', 1) . '">' . $langs->trans('BackToList') . '</a>';
-    saturne_banner_tab($objectsMetadata[$fromType]['object'], 'fromtype=' . $fromType . '&fromid', $linkBack, 1, 'rowid', ($fromType == 'productlot' ? 'batch' : 'ref'));
+if (!empty($fromObjectMetadata) && !empty($fromId)) {
+    $fromObject = $fromObjectMetadata['object'];
+    $fromObject->fetch($fromId);
+    saturne_get_fiche_head($fromObject, $object->element, $langs->trans(ucfirst($object->element)));
+
+    // The list of the element is reached through its own path : fromtype is a link name, not a directory
+    $backUrl  = $fromObjectMetadata['list_url'] ?: $fromType . '/list.php';
+    $linkBack = '<a href="' . dol_buildpath($backUrl . '?restore_lastsearch_values=1', 1) . '">' . $langs->trans('BackToList') . '</a>';
+    saturne_banner_tab($fromObject, 'fromtype=' . $fromType . '&fromid', $linkBack, 1, 'rowid', ($fromType == 'productlot' ? 'batch' : 'ref'));
 
     $moreUrlParameters = '&fromtype=' . $fromType . '&fromid=' . $fromId;
     $formMoreParams    = ['fromtype' => $fromType, 'fromid' => $fromId];


### PR DESCRIPTION
## Problème

Ouvrir l'onglet Contrôles ou Questionnaires depuis une commande client provoque un fatal error :

```
Fatal error: Uncaught Error: Call to a member function fetch() on null
in .../custom/digiquali/view/control/control_list.php:269
```

## Cause

Les onglets sont déclarés avec le `link_name` de l'élément (`fromtype=commande`), alors que le tableau
renvoyé par `saturne_get_objects_metadata()` est indexé par clé d'objet (`order`). Lire le tableau avec
`fromtype` tombe donc sur une entrée absente, et `$objectsMetadata['commande']['object']` vaut `null`.

Dix objets ont une clé différente de leur `link_name` :

| Clé | `link_name` (= `fromtype`) |
|---|---|
| thirdparty | societe |
| invoice | facture |
| order | commande |
| entrepot | stock |
| inventory | stock_inventory |
| mouvement | stockmouvement |
| supplier_order | order_supplier |
| mrp | mo |
| task | project_task |
| contract | contrat |

`task` et `contract` disposent déjà d'entrées alias dans saturne, ce qui masquait le problème pour eux
uniquement. Tous les autres tombaient en fatal.

## Correction

- Nouvelle fonction `digiquali_get_object_metadata_from_link_name()` qui résout l'entrée de métadonnées
  par son `link_name` au lieu de la clé du tableau.
- `control_list.php` et `survey_list.php` résolvent l'entrée une seule fois dans `$fromObjectMetadata`,
  réutilisée pour la bannière et pour le filtre de recherche. La valeur reste vide pour les `fromtype`
  qui ne désignent aucun objet (`fk_sheet`) : la bannière est alors simplement omise au lieu de planter.
- Le filtre `$search[...]` était posé sur une clé vide, donc l'onglet affichait tous les contrôles au
  lieu de ceux de l'élément. Il porte maintenant sur le bon `post_name` (`fk_order`, `fk_invoice`, ...).
- Le lien « Retour à la liste » de la bannière était construit en `fromtype . '/list.php'`, ce qui donnait
  une URL inexistante pour les factures (`facture/list.php` au lieu de `compta/facture/list.php`), les
  lots et les entrepôts. Il s'appuie maintenant sur le `list_url` des métadonnées.
- `control_card.php` : même origine, sans fatal. Le libellé proposé au clonage d'un contrôle retombait
  sur la référence du contrôle au lieu de celle de l'élément lié.

## Fichiers modifiés

- `lib/digiquali_linked_object.lib.php`
- `view/control/control_list.php`
- `view/survey/survey_list.php`
- `view/control/control_card.php`

## Tests

- Onglets Contrôles et Questionnaires ouverts depuis une commande, une facture, un tiers et un entrepôt :
  plus de fatal, la bannière de l'élément s'affiche et la liste est filtrée sur cet élément.
- Non-régression sur les objets dont la clé vaut déjà le `link_name` (produit, lot, utilisateur, projet).
- `fromtype` sans objet correspondant (`fk_sheet`) et `fromtype` vide : pas d'erreur, bannière omise.

Close #2560
