### PR TITLE
#2563 [PublicAnswer] fix: photo upload on the public answer interface

### DIFF
--- a/lib/digiquali_answer.lib.php
+++ b/lib/digiquali_answer.lib.php
@@ -208,3 +208,48 @@ function show_answer_from_question(Question $question, CommonObject $object, str
 
     return $out;
 }
+
+/**
+ * Check that a media block action targets one of the answered object's own directories
+ *
+ * The public answer page has no authenticated user: the track ID is its only credential, so the
+ * directory posted by js/modules/mediaBlock.js must be confined to the answered object. Without
+ * this, anyone holding a track ID could write into or delete from any directory of the module.
+ *
+ * @param  CommonObject $object Answered object (control or survey)
+ * @param  string       $action Action posted by the media block
+ * @return bool                 True when the posted target belongs to $object
+ */
+function digiquali_answer_media_dir_is_allowed(CommonObject $object, string $action): bool
+{
+    global $db;
+
+    $subDir = GETPOST('sub_dir', 'alpha');
+    if (dol_strtolower(GETPOST('module_name', 'alpha')) != 'digiquali' || strpos($subDir, '..') !== false) {
+        return false;
+    }
+
+    switch ($action) {
+        case 'uploadPhoto':
+        case 'deletePhoto':
+            // Answer photos are stored in <element>/<object ref>/answer_photo/<question ref>
+            $photoDir    = $object->element . '/' . dol_sanitizeFileName($object->ref) . '/answer_photo/';
+            $questionRef = strpos($subDir, $photoDir) === 0 ? substr($subDir, dol_strlen($photoDir)) : '';
+            return dol_strlen($questionRef) > 0 && strpos($questionRef, '/') === false;
+
+        case 'uploadFile':
+            // The upload resolves its directory from the answer line it creates, not from sub_dir
+            return $object->element == 'control' && GETPOSTINT('fk_control') == $object->id && GETPOSTINT('fk_question') > 0;
+
+        case 'deleteFile':
+            // Attached documents are stored in controldet/<answer line ref>
+            $lineRef = strpos($subDir, 'controldet/') === 0 ? substr($subDir, dol_strlen('controldet/')) : '';
+            if ($object->element != 'control' || dol_strlen($lineRef) == 0 || strpos($lineRef, '/') !== false) {
+                return false;
+            }
+            $objectLine = new ControlLine($db);
+            return $objectLine->fetch(0, $lineRef) > 0 && $objectLine->fk_control == $object->id;
+    }
+
+    return false;
+}

--- a/public/public_answer.php
+++ b/public/public_answer.php
@@ -148,6 +148,14 @@ if (empty($resHook)) {
     // Set user for action update and insert for prevent error on public interface
     $user->id = 1;
 
+    // Actions uploadPhoto, uploadFile, deletePhoto, deleteFile posted by the Saturne media block.
+    // It replays the HTML of the response to refresh itself, so this must not redirect
+    if (in_array($action, ['uploadPhoto', 'uploadFile', 'deletePhoto', 'deleteFile'])) {
+        if ($object->id > 0 && $object->status == $object::STATUS_DRAFT && digiquali_answer_media_dir_is_allowed($object, $action)) {
+            require_once __DIR__ . '/../core/tpl/actions/digiquali_media_block_actions.tpl.php';
+        }
+    }
+
     require_once __DIR__ . '/../core/tpl/digiquali_answers_save_action.tpl.php';
 }
 
@@ -213,6 +221,9 @@ $wizardSummaryExtraHtml = ob_get_clean();
 require __DIR__ . '/../core/tpl/frontend/digiquali_answer_wizard.tpl.php';
 print '</div>';
 print '</form>';
+
+// Required by the media block: without it, picking a photo silently does nothing
+require_once __DIR__ . '/../../saturne/core/tpl/medias/photo_editor_modal.tpl.php';
 
 llxFooter('', 'public');
 $db->close();


### PR DESCRIPTION
## Changements

Sur l'interface publique de réponse, choisir une photo ne produisait strictement rien : deux maillons du bloc média Saturne manquaient sur cette page, alors qu'ils sont bien câblés sur la fiche contrôle et sur l'écran de réponse PWA.

- `public/public_answer.php` : inclusion de `saturne/core/tpl/medias/photo_editor_modal.tpl.php`. Sans la modale dans le DOM, `window.saturne.photoEditor.open()` fait un `return` immédiat, d'où l'échec totalement silencieux.
- `public/public_answer.php` : traitement des actions `uploadPhoto`, `uploadFile`, `deletePhoto` et `deleteFile` postées en AJAX par `js/modules/mediaBlock.js`, sans redirection puisque le JS rejoue le HTML de la réponse pour rafraîchir le bloc.
- `lib/digiquali_answer.lib.php` : nouvelle `digiquali_answer_media_dir_is_allowed()`. La page est en `NOLOGIN` / `NOCSRFCHECK`, le `track_id` est le seul justificatif : le `sub_dir` posté est donc confronté au dossier attendu de l'objet répondu (`<element>/<ref>/answer_photo/<ref question>`, `controldet/<ref ligne>` avec le `fk_control` vérifié) et l'objet doit être en brouillon. Sans ce garde-fou, tout porteur d'un `track_id` pouvait écrire ou supprimer dans n'importe quel dossier de `documents/digiquali/`.

## Tests

Vérifié en local sur le contrôle `FC2606-0039` (brouillon, question `QU2407-0134` avec photo de réponse autorisée), en rejouant les requêtes du bloc média :

| Cas | Résultat |
|---|---|
| Rendu de la page publique | modale présente, aucune erreur PHP |
| `action=uploadPhoto` | fichier et vignettes écrits, compteur de galerie à 1 dans la réponse renvoyée |
| `action=uploadPhoto` avec `sub_dir=sheet` | refusé, rien écrit |
| `action=deletePhoto` | fichier supprimé |
| `action=uploadFile` | document écrit dans `controldet/<ref>` |
| `action=uploadFile` avec le `fk_control` d'un autre contrôle | refusé, rien écrit |
| `action=deleteFile` | document supprimé |

## Fichiers modifiés

- `public/public_answer.php`
- `lib/digiquali_answer.lib.php`

Close #2563
