### PR TITLE
#2567 [Mod] fix: retirer les dependances de modules inutiles

### DIFF
--- a/core/modules/modDigiQuali.class.php
+++ b/core/modules/modDigiQuali.class.php
@@ -153,7 +153,8 @@ class modDigiQuali extends DolibarrModules
 		// A condition to hide module
 		$this->hidden = false;
 		// List of module class names as string that must be enabled if this module is enabled. Example: array('always1'=>'modModuleToEnable1','always2'=>'modModuleToEnable2', 'FR1'=>'modModuleToEnableFR'...)
-		$this->depends = ['modFckeditor', 'modProduct', 'modProductBatch', 'modECM', 'modProjet', 'modCategorie', 'modSaturne', 'modTicket', 'modCron'];
+		// ECM, Agenda, Fckeditor et Categorie sont declares par Saturne et herites de lui
+		$this->depends = ['modSaturne', 'modProjet'];
 		$this->requiredby = []; // List of module class names as string to disable if this one is disabled. Example: array('modModuleToDisable1', ...)
 		$this->conflictwith = []; // List of module class names as string this module is in conflict with. Example: array('modModuleToDisable1', ...)
 


### PR DESCRIPTION
Closes #2567

Depend de Evarisk/Saturne#1571, a merger en premier.

## Probleme

`$this->depends` declarait 9 modules et `activateModule()` les allume en cascade (`htdocs/core/lib/admin.lib.php:1264-1284`). Deux d'entre eux en tirent d'autres :

- `modProductBatch -> modProduct, modStock, modExpedition, modFournisseur`
- `modTicket -> modAgenda`

Cocher DigiQuali allumait donc **13 modules**, dont Stock, Expeditions et Fournisseurs.

## Correction

```php
$this->depends = ['modSaturne', 'modProjet'];
```

### Dependances conservees

| Module | Pourquoi |
|---|---|
| `modSaturne` | socle |
| `modProjet` | `DIGIQUALI_SHEET_LINK_PROJECT` vaut 1 par defaut |

### Dependances desormais heritees de Saturne

`modECM`, `modFckeditor` et `modCategorie` sont declares par Saturne (Evarisk/Saturne#1571), qui y ajoute `modAgenda` : leur besoin naît dans le socle (galerie medias, champs `type => html`, tags des listes generiques, trigger et onglet Evenements), pas dans DigiQuali.

### Dependances supprimees

- **`modProduct` / `modProductBatch`** : les liens sont desactives par defaut (`DIGIQUALI_SHEET_LINK_PRODUCT` et `_PRODUCTLOT` a 0) et tout le code produit est deja garde — `saturne_get_objects_metadata()` teste `isModEnabled()` objet par objet (`saturne/lib/object.lib.php:379-404`), plus `lib/digiquali_control.lib.php:509` et `view/control/control_list.php:300`. A elles deux, ces dependances allumaient 5 modules.
- **`modTicket`** : `DIGIQUALI_SHEET_LINK_TICKET` vaut 0 par defaut et le lien passe par le meme filtre `isModEnabled()`. Les `require_once` de `core/lib/ticket.lib.php` (`class/control.class.php:25`, `class/survey.class.php:25`, `view/digiqualitools.php:34`) sont conserves : ils chargent `generate_random_id()`, utilisee pour le `track_id` des controles et des questionnaires. C'est une fonction de librairie du coeur, disponible que le module Ticket soit actif ou non.
- **`modCron`** : `$this->cronjobs = []`, aucun job planifie.

## Portee

13 modules actives -> 6 (Saturne, ECM, Agenda, Fckeditor, Categorie, Projet). Stock, Expeditions, Fournisseurs, Produits, Lots, Tickets et Travaux planifies ne sont plus allumes sans avoir ete demandes.

Aucun effet sur les installations existantes : Dolibarr ne desactive un module que via `requiredby`, les modules deja allumes le restent, et les liaisons produit/lot/ticket restent activables depuis la configuration des modeles des que le module correspondant est actif.

## Test

- `php -l` OK.
- Activation de DigiQuali sur une instance vierge : les 6 modules attendus s'allument, aucun autre.
- Creation d'un controle : `track_id` toujours genere, l'interface publique fonctionne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)