### PR TITLE
#2571 [Menu] fix: lien Tags vers la page de tags du type au lieu de la liste des types

### DIFF
--- a/core/modules/modDigiQuali.class.php
+++ b/core/modules/modDigiQuali.class.php
@@ -606,6 +606,9 @@ class modDigiQuali extends DolibarrModules
 		$this->menu = [];
 		$r = 0;
 
+		// Since Dolibarr 22, categories/index.php only lists the tag types and ignores the type parameter, the page dedicated to a single type is categorie_list.php
+		$tagListUrl = ((float) DOL_VERSION >= 22.0 ? '/categories/categorie_list.php?type=' : '/categories/index.php?type=');
+
 		// Add here entries to declare new menus
 		$this->menu[$r++] = [
 			'fk_menu'  => 'fk_mainmenu=digiquali',
@@ -661,7 +664,7 @@ class modDigiQuali extends DolibarrModules
 			'titre'    => '<i class="fas fa-tags pictofixedwidth" style="padding-right: 4px;"></i>' . $langs->transnoentities('Categories'),
 			'mainmenu' => 'digiquali',
 			'leftmenu' => 'digiquali_questiontags',
-			'url'      => '/categories/index.php?type=question',
+			'url'      => $tagListUrl . 'question',
 			'langs'    => 'digiquali@digiquali',
 			'position' => 1000 + $r,
 			'enabled'  => '$conf->digiquali->enabled && $conf->categorie->enabled && $user->rights->digiquali->question->read',
@@ -692,7 +695,7 @@ class modDigiQuali extends DolibarrModules
         //     'titre'    => '<i class="fas fa-tags pictofixedwidth" style="padding-right: 4px;"></i>' . $langs->transnoentities('Categories'),
         //     'mainmenu' => 'digiquali',
         //     'leftmenu' => 'digiquali_questiongrouptags',
-        //     'url'      => '/categories/index.php?type=question_group',
+        //     'url'      => $tagListUrl . 'question_group',
         //     'langs'    => 'digiquali@digiquali',
         //     'position' => 1000 + $r,
         //     'enabled'  => '$conf->digiquali->enabled && $conf->categorie->enabled && $user->rights->digiquali->questiongroup->read',
@@ -723,7 +726,7 @@ class modDigiQuali extends DolibarrModules
 			'titre'    => '<i class="fas fa-tags pictofixedwidth" style="padding-right: 4px;"></i>' . $langs->transnoentities('Categories'),
 			'mainmenu' => 'digiquali',
 			'leftmenu' => 'digiquali_sheettags',
-			'url'      => '/categories/index.php?type=sheet',
+			'url'      => $tagListUrl . 'sheet',
 			'langs'    => 'digiquali@digiquali',
 			'position' => 1000 + $r,
 			'enabled'  => '$conf->digiquali->enabled && $conf->categorie->enabled && $user->rights->digiquali->sheet->read',
@@ -769,7 +772,7 @@ class modDigiQuali extends DolibarrModules
 			'titre'    => '<i class="fas fa-tags pictofixedwidth" style="padding-right: 4px;"></i>' . $langs->transnoentities('Categories'),
 			'mainmenu' => 'digiquali',
 			'leftmenu' => 'digiquali_controltags',
-			'url'      => '/categories/index.php?type=control',
+			'url'      => $tagListUrl . 'control',
 			'langs'    => 'digiquali@digiquali',
 			'position' => 1000 + $r,
 			'enabled'  => '$conf->digiquali->enabled && $conf->categorie->enabled && $user->rights->digiquali->control->read',
@@ -800,7 +803,7 @@ class modDigiQuali extends DolibarrModules
             'titre'    => '<i class="fas fa-tags pictofixedwidth" style="padding-right: 4px;"></i>' . $langs->transnoentities('Categories'),
             'mainmenu' => 'digiquali',
             'leftmenu' => 'digiquali_surveytags',
-            'url'      => '/categories/index.php?type=survey',
+            'url'      => $tagListUrl . 'survey',
             'langs'    => 'digiquali@digiquali',
             'position' => 1000 + $r,
             'enabled'  => '$conf->digiquali->enabled && $conf->categorie->enabled && $user->rights->digiquali->survey->read',


### PR DESCRIPTION
## Problème

Les entrées « Tags » du menu de gauche (Question, Modèle, Contrôle, Questionnaire) pointaient vers `/categories/index.php?type=<code>`.

Depuis Dolibarr 22, cette page a été réécrite : elle ne lit plus du tout le paramètre `type` et se contente de lister **tous** les types de tags. Le clic amenait donc sur la liste générique au lieu des tags du type demandé — d'où l'impression que le lien ne fonctionne pas.

La page dédiée à un type est désormais `/categories/categorie_list.php?type=<code>`, comme l'utilisent déjà Digirisk et les modules du cœur (`modTicket`, `modKnowledgeManagement`).

## Changements

- `modDigiQuali.class.php` : nouvelle variable `$tagListUrl` calculée une fois avant la définition des menus, utilisée par les 4 entrées « Tags » (+ l'entrée QuestionGroup commentée).
- Le module annonçant `need_dolibarr_version = [21, 0]` et `categorie_list.php` n'existant pas en 21.0, l'URL reste `index.php` en dessous de la 22 pour ne pas créer un 404 chez ces utilisateurs.

```php
$tagListUrl = ((float) DOL_VERSION >= 22.0 ? '/categories/categorie_list.php?type=' : '/categories/index.php?type=');
```

## Tests

- Descripteur instancié en CLI : les 4 entrées sortent bien en `/categories/categorie_list.php?type=question|sheet|control|survey` sur Dolibarr 23.0.3.
- Menu de gauche re-rendu après mise à jour de `llx_menu` : les `href` pointent sur la bonne page pour les 4 types.
- `categorie_list.php?type=survey` affiche « Categories (Survey) » avec le bouton de création de tag.

⚠️ Les entrées de menu vivent dans `llx_menu` : **réactivation du module nécessaire** pour que la nouvelle URL prenne effet.

## À noter

La même URL périmée subsiste sur les boutons « + » à côté du sélecteur de tags des fiches (`view/control/control_card.php`, `view/question/question_card.php`, `view/sheet/sheet_card.php`, `view/survey/survey_card.php`). Volontairement hors périmètre de cette issue, à traiter séparément — idéalement en passant par `Form::selectCategories()` du cœur, qui rend déjà le multiselect et son bouton d'ajout en popup.

## Fichiers modifiés

- `core/modules/modDigiQuali.class.php`

Close #2571
