### PR TITLE
#2574 [Sheet] fix: colonne des objets contrôlés lisible au lieu du JSON brut

### DIFF
--- a/class/actions_digiquali.class.php
+++ b/class/actions_digiquali.class.php
@@ -1165,6 +1165,28 @@ class ActionsDigiquali
                 $out[$parameters['key']] = saturne_show_medias_linked('digiquali', $conf->digiquali->multidir_output[$object->entity] . '/sheet/' . $object->ref . '/photos/', 'small', 0, 0, 0, 0, 50, 50, 0, 0, 0, 'sheet/' . $object->ref . '/photos/', $object, 'photo', 0, 0);
             }
 
+            // element_linked stores the controllable object types as a JSON map ({"project":1}), which the
+            // generic list would print as is: render the object labels instead of the raw JSON
+            if ($parameters['key'] == 'element_linked') {
+                $objectsMetadata = $conf->cache['objectsMetadata'] ?? [];
+                $linkedElements  = json_decode($object->element_linked ?? '', true);
+                $labels          = [];
+                if (is_array($linkedElements)) {
+                    foreach ($linkedElements as $objectType => $isObjectLinked) {
+                        if (empty($isObjectLinked)) {
+                            continue;
+                        }
+                        // An imported model can carry an object type this instance does not know (module
+                        // disabled or not installed): fall back on the type itself rather than dropping it
+                        $objectMetadata = $objectsMetadata[$objectType] ?? [];
+                        $picto          = !empty($objectMetadata['picto']) ? img_picto('', $objectMetadata['picto'], 'class="pictofixedwidth"') : '';
+                        $labels[]       = $picto . $langs->trans(!empty($objectMetadata['langs']) ? $objectMetadata['langs'] : ucfirst($objectType));
+                    }
+                }
+                // Always feed the column, an empty value would let the template fall back on the raw field
+                $out[$parameters['key']] = !empty($labels) ? implode('<br>', $labels) : '<span class="opacitymedium">' . $langs->trans('None') . '</span>';
+            }
+
             $this->results = $out;
         }
 

--- a/langs/en_US/digiquali.lang
+++ b/langs/en_US/digiquali.lang
@@ -53,6 +53,7 @@ LinkCall_listDescription=Allows linking between call lists and templates
 
 # Linkable elements
 LinkableElements                        = Linkable elements
+ElementLinked                           = Controlled objects
 LinkedObjectUsage                       = Usage
 LinkedObjectUsageDetail                 = %d link(s), %d control frequency value(s)
 NoLinkedObjectUsage                     = Not used

--- a/langs/fr_FR/digiquali.lang
+++ b/langs/fr_FR/digiquali.lang
@@ -50,6 +50,7 @@ DefaultControlTagsHelp         = Catégories qui seront pré-sélectionnées lor
 DefaultControlProject          = Projet par défaut du contrôle
 ConfigureYourObjectsHere       = Configurez vos Objets ici
 ControlledObjectsTitle         = Objets contrôlés par ce Contrôle/Questionnaire
+ElementLinked                  = Objets contrôlés
 
 # Control - Contrôle
 DisplayMediasSample                                = Afficher les médias d'exemple des questions

--- a/view/sheet/sheet_list.php
+++ b/view/sheet/sheet_list.php
@@ -37,6 +37,7 @@ if (isModEnabled('categorie')) {
 
 // load DigiQuali libraries
 require_once __DIR__ . '/../../class/sheet.class.php';
+require_once __DIR__ . '/../../../saturne/lib/object.lib.php';
 
 // Global variables definitions
 global $conf, $db, $hookmanager, $langs, $user;
@@ -94,6 +95,7 @@ if (!$sortorder) {
 }
 
 // Definition of custom fields for columns
+$conf->cache['objectsMetadata'] = saturne_get_objects_metadata(); // Read back by the saturnePrintFieldListLoopObject hook to render the element_linked column
 $object->fields['nb_questions'] = ['label' => 'NbQuestions', 'enabled' => 1, 'visible' => 2, 'position' => 16, 'disablesort' => 1, 'csslist' => 'center'];
 $excludeFields                  = ['nb_questions'];
 


### PR DESCRIPTION
## Problème

Sur la liste des modèles, la colonne « objets contrôlés » avait deux défauts :

- **L'en-tête n'était pas traduit** : la clé `ElementLinked` n'existe dans aucun fichier `.lang` (ni DigiQuali, ni Saturne, ni le cœur), la colonne s'affichait donc `ElementLinked`.
- **La cellule affichait le JSON brut** `{"project":1}` : `element_linked` est un champ `text` que la liste générique imprime tel quel, et aucun rendu n'était branché pour cette clé — contrairement à `nb_questions` et `photo`, qui ont déjà leur cas dans le hook `saturnePrintFieldListLoopObject`.

Ce n'est pas lié à l'import, contrairement à ce que laissait penser le ticket : en base, les modèles importés et ceux créés à la main stockent exactement le même format (`{"project":1}`), et la colonne affichait le JSON pour tous.

## Changements

- `langs/fr_FR` et `langs/en_US` : ajout de `ElementLinked` (« Objets contrôlés » / « Controlled objects »). Profite aussi à `Sheet::getTriggerDescription()`, qui utilisait la clé sans traduction.
- `view/sheet/sheet_list.php` : mise en cache des métadonnées objets dans `$conf->cache['objectsMetadata']`, comme le fait déjà `survey_list.php`.
- `class/actions_digiquali.class.php` : rendu de la clé `element_linked` dans la branche `sheetlist` du hook — picto + libellé traduit de chaque objet coché.

Deux cas limites traités :

- un modèle importé peut référencer un type d'objet que l'instance ne connaît pas (module désactivé ou absent) : repli sur le nom du type plutôt que de perdre l'information ;
- un modèle sans objet à contrôler affiche « Aucun » en gris. La valeur doit rester non vide, sinon le template retombe sur l'affichage brut du champ.

## Tests

Page de liste réellement rendue sur un jeu de données couvrant `product`, `project`, `productlot`, `contract`, `user`, `digiriskdolibarr_digiriskelement`, `digiriskdolibarr_firepermit` et un `element_linked` vide :

- plus aucun JSON dans la colonne, on lit « Projet », « Contrat », « Lot/Série », « Produit ou Service », « Groupement / Unité de travail » avec leur picto ;
- « Aucun » pour le modèle sans objet à contrôler ;
- l'objet fourni par Digirisk se résout bien dans le contexte `sheetlist` ;
- repli vérifié sur un type inconnu (`{"unknownobject":1,"project":1}`).

La colonne reste masquée par défaut (`visible => -2`) : elle s'ajoute via le sélecteur de colonnes de la liste.

## Fichiers modifiés

- `class/actions_digiquali.class.php`
- `langs/fr_FR/digiquali.lang`
- `langs/en_US/digiquali.lang`
- `view/sheet/sheet_list.php`

Close #2574
