### PR TITLE
#2575 [Onglets] fix: onglets Contrôles et Questionnaires absents des fiches d'intervention

### DIFF
--- a/core/modules/modDigiQuali.class.php
+++ b/core/modules/modDigiQuali.class.php
@@ -328,6 +328,12 @@ class modDigiQuali extends DolibarrModules
             $linkableObjects = saturne_filter_linkable_objects(saturne_get_objects_metadata(), ['digiquali_']);
         }
         
+        // Dolibarr does not always name the tab type after the object: the intervention card completes
+        // its head with 'intervention', not 'fichinter'. And the supplier order key holds an underscore,
+        // so it would otherwise be split as if it came from an external module. Saturne's tab_type is
+        // left untouched, EasyURL stores it as the element type of its shortened links
+        $dolibarrTabTypes = ['ficheinter' => 'intervention', 'supplier_order' => 'supplier_order'];
+
         $enabledObjectTypes = [];
         if (function_exists('saturne_get_enabled_linked_object_types')) {
             $enabledObjectTypes = saturne_get_enabled_linked_object_types($linkableObjects, 'DIGIQUALI_SHEET_LINK_');
@@ -336,7 +342,9 @@ class modDigiQuali extends DolibarrModules
         foreach ($enabledObjectTypes as $objectType) {
             $objectMetadata = $linkableObjects[$objectType];
 
-            if (preg_match('/_/', $objectType)) {
+            if (isset($dolibarrTabTypes[$objectType])) {
+                $tabType = $dolibarrTabTypes[$objectType];
+            } elseif (preg_match('/_/', $objectType)) {
                 $splittedElementType = explode('_', $objectType);
                 $moduleName = $splittedElementType[0];
                 $objectName = dol_strtolower($objectMetadata['class_name']);


### PR DESCRIPTION
## Problème

Les onglets « Contrôles » et « Questionnaires » n'apparaissent pas sur la fiche d'intervention, alors que le lien est bien actif (l'extrafield « Périodicité de contrôle » est là).

`complete_head_from_modules()` ne retient que les onglets déclarés sous **exactement** le type que la carte lui passe. La carte d'intervention appelle :

```php
complete_head_from_modules($conf, $langs, $object, $head, $h, 'intervention', ...); // core/lib/fichinter.lib.php
```

alors que DigiQuali déclare ses onglets à partir de `tab_type` des métadonnées Saturne, qui vaut `fichinter` pour cet objet. Le type ne correspond jamais, l'onglet n'est donc jamais monté.

Même symptôme sur la **commande fournisseur**, pour une autre raison : sa clé `supplier_order` contient un `_`, donc la branche prévue pour les objets des modules externes la découpait en `commandefournisseur@supplier` au lieu de laisser `supplier_order`.

## Changements

`modDigiQuali.class.php` : une table de correspondance pour les objets du cœur dont le type d'onglet Dolibarr ne porte pas le nom de l'objet, consultée avant les deux branches existantes.

```php
$dolibarrTabTypes = ['ficheinter' => 'intervention', 'supplier_order' => 'supplier_order'];
```

Le `tab_type` de Saturne n'est volontairement pas corrigé : EasyURL le stocke comme `element_type` de ses liens raccourcis (`shortener.class.php`), le changer orphelinerait les lignes existantes. La correction reste donc côté consommateur.

La branche des objets de modules externes (`digiriskdolibarr_*`, `dolicar_*`, `dolimeet_*`) est laissée telle quelle, pour ne rien déplacer sur ces onglets.

## Tests

Descripteur instancié en CLI avec les modules Interventions et Fournisseurs simulés actifs et leurs liens activés, en comparant les types déclarés à ceux que chaque carte Dolibarr demande :

| Objet | Type attendu par la carte | Avant | Après |
|---|---|---|---|
| Intervention | `intervention` | `fichinter` — manquant | OK |
| Commande fournisseur | `supplier_order` | `commandefournisseur@supplier` — manquant | OK |
| Projet, produit, ticket, tâche, contrat… | inchangés | OK | OK |
| Objets Digirisk | `<objet>@digiriskdolibarr` | OK | inchangé |

⚠️ Les onglets sont stockés en base (`MAIN_MODULE_DIGIQUALI_TABS_*`) au moment de l'activation : **réactivation du module nécessaire** pour que les onglets apparaissent.

## À noter

L'expédition déclare `delivery` comme type d'onglet alors que sa carte utilise `order` : elle hérite donc de l'onglet de la commande. Le mapper explicitement créerait un onglet en double quand les deux liens sont actifs, ce cas est laissé en l'état.

## Fichiers modifiés

- `core/modules/modDigiQuali.class.php`

Close #2575
