### PR TITLE
#2569 [Boutons] fix: cadenas ouvert sur le bouton verrouiller, fermé sur le bouton réouvrir

### DIFF
--- a/class/actions_digiquali.class.php
+++ b/class/actions_digiquali.class.php
@@ -1011,7 +1011,7 @@ class ActionsDigiquali
         global $langs;
 
         if (strpos($parameters['context'], 'questionlist') !== false) {
-            $arrayOfMassactions['prelock']           = '<span class="fas fa-lock paddingrightonly"></span>' . $langs->trans('Lock');
+            $arrayOfMassactions['prelock']           = '<span class="fas fa-lock-open paddingrightonly"></span>' . $langs->trans('Lock');
             $arrayOfMassactions['pre_add_questions'] = '<span class="fas fa-plus-circle paddingrightonly"></span>' . $langs->transnoentities('AddToSheet');
 
             $out  = '<option value="prelock" data-html="' . dol_escape_htmltag($arrayOfMassactions['prelock']) . '">' . $arrayOfMassactions['prelock'] . '</option>';

--- a/view/control/control_card.php
+++ b/view/control/control_card.php
@@ -917,7 +917,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'create'))) {
             }
 
             // ReOpen
-            $displayButton = $onPhone ? '<i class="fas fa-lock-open fa-2x"></i>' : '<i class="fas fa-lock-open"></i>' . ' ' . $langs->trans('ReOpenDoli');
+            $displayButton = $onPhone ? '<i class="fas fa-lock fa-2x"></i>' : '<i class="fas fa-lock"></i>' . ' ' . $langs->trans('ReOpenDoli');
             if ($object->status == Control::STATUS_VALIDATED) {
                 print '<span class="butAction" id="actionButtonInProgress">' . $displayButton . '</span>';
             } elseif ($object->status > Control::STATUS_VALIDATED) {
@@ -947,7 +947,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'create'))) {
             }
 
             // Lock
-            $displayButton = $onPhone ? '<i class="fas fa-lock fa-2x"></i>' : '<i class="fas fa-lock"></i>' . ' ' . $langs->trans('Lock');
+            $displayButton = $onPhone ? '<i class="fas fa-lock-open fa-2x"></i>' : '<i class="fas fa-lock-open"></i>' . ' ' . $langs->trans('Lock');
             if ($object->status == $object::STATUS_VALIDATED && $object->verdict != null && $signatory->checkSignatoriesSignatures($object->id, $object->element) && !$equipmentOutdated) {
                 print '<span class="butAction" id="actionButtonLock">' . $displayButton . '</span>';
             } else {

--- a/view/question/question_card.php
+++ b/view/question/question_card.php
@@ -1452,11 +1452,11 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 			// Lock
 			if (($object->type == 'UniqueChoice' || $object->type == 'MultipleChoices') && empty($answerList)) {
-				print '<span class="butActionRefused classfortooltip" title="' . dol_escape_htmltag($langs->trans('AnswerMustBeCreated')) . '"><i class="fas fa-lock"></i> ' . $langs->trans('Lock') . '</span>';
+				print '<span class="butActionRefused classfortooltip" title="' . dol_escape_htmltag($langs->trans('AnswerMustBeCreated')) . '"><i class="fas fa-lock-open"></i> ' . $langs->trans('Lock') . '</span>';
 			} else if ($object->status == $object::STATUS_VALIDATED) {
-				print '<span class="butAction" id="actionButtonLock"><i class="fas fa-lock"></i> ' . $langs->trans('Lock') . '</span>';
+				print '<span class="butAction" id="actionButtonLock"><i class="fas fa-lock-open"></i> ' . $langs->trans('Lock') . '</span>';
 			} else {
-				print '<span class="butActionRefused classfortooltip" title="' . dol_escape_htmltag($langs->trans('ObjectMustBeValidated', $langs->transnoentities('The' . ucfirst($object->element)))) . '"><i class="fas fa-lock"></i> ' . $langs->trans('Lock') . '</span>';
+				print '<span class="butActionRefused classfortooltip" title="' . dol_escape_htmltag($langs->trans('ObjectMustBeValidated', $langs->transnoentities('The' . ucfirst($object->element)))) . '"><i class="fas fa-lock-open"></i> ' . $langs->trans('Lock') . '</span>';
 			}
 
 			// Archive

--- a/view/questiongroup/questiongroup_card.php
+++ b/view/questiongroup/questiongroup_card.php
@@ -389,9 +389,9 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 			// Lock
 			if ($object->status == $object::STATUS_VALIDATED) {
-				print '<span class="butAction" id="actionButtonLock"><i class="fas fa-lock"></i> ' . $langs->trans('Lock') . '</span>';
+				print '<span class="butAction" id="actionButtonLock"><i class="fas fa-lock-open"></i> ' . $langs->trans('Lock') . '</span>';
 			} else {
-				print '<span class="butActionRefused classfortooltip" title="' . dol_escape_htmltag($langs->trans('ObjectMustBeValidated', $langs->transnoentities('The' . ucfirst($object->element)))) . '"><i class="fas fa-lock"></i> ' . $langs->trans('Lock') . '</span>';
+				print '<span class="butActionRefused classfortooltip" title="' . dol_escape_htmltag($langs->trans('ObjectMustBeValidated', $langs->transnoentities('The' . ucfirst($object->element)))) . '"><i class="fas fa-lock-open"></i> ' . $langs->trans('Lock') . '</span>';
 			}
 
 			// Archive

--- a/view/sheet/sheet_card.php
+++ b/view/sheet/sheet_card.php
@@ -1007,9 +1007,9 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 			// Lock
 			if ($object->status == $object::STATUS_VALIDATED) {
-				print '<span class="butAction" id="actionButtonLock"><i class="fas fa-lock"></i> ' . $langs->trans('Lock') . '</span>';
+				print '<span class="butAction" id="actionButtonLock"><i class="fas fa-lock-open"></i> ' . $langs->trans('Lock') . '</span>';
 			} else {
-				print '<span class="butActionRefused classfortooltip" title="' . dol_escape_htmltag($langs->trans('ObjectMustBeValidated', $langs->transnoentities('The' . ucfirst($object->element)))) . '"><i class="fas fa-lock"></i> ' . $langs->trans('Lock') . '</span>';
+				print '<span class="butActionRefused classfortooltip" title="' . dol_escape_htmltag($langs->trans('ObjectMustBeValidated', $langs->transnoentities('The' . ucfirst($object->element)))) . '"><i class="fas fa-lock-open"></i> ' . $langs->trans('Lock') . '</span>';
 			}
 
 			// Clone

--- a/view/survey/survey_card.php
+++ b/view/survey/survey_card.php
@@ -611,7 +611,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
             }
 
             // ReOpen
-            $displayButton = $onPhone ? '<i class="fas fa-lock-open fa-2x"></i>' : '<i class="fas fa-lock-open"></i>' . ' ' . $langs->trans('ReOpenDoli');
+            $displayButton = $onPhone ? '<i class="fas fa-lock fa-2x"></i>' : '<i class="fas fa-lock"></i>' . ' ' . $langs->trans('ReOpenDoli');
             if ($object->status == Survey::STATUS_VALIDATED) {
                 print '<span class="butAction" id="actionButtonInProgress">' . $displayButton . '</span>';
             } elseif ($object->status > Survey::STATUS_VALIDATED) {
@@ -627,7 +627,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
             }
 
             // Lock
-            $displayButton = $onPhone ? '<i class="fas fa-lock fa-2x"></i>' : '<i class="fas fa-lock"></i>' . ' ' . $langs->trans('Lock');
+            $displayButton = $onPhone ? '<i class="fas fa-lock-open fa-2x"></i>' : '<i class="fas fa-lock-open"></i>' . ' ' . $langs->trans('Lock');
             if ($object->status == Survey::STATUS_VALIDATED && $signatory->checkSignatoriesSignatures($object->id, $object->element)) {
                 print '<span class="butAction" id="actionButtonLock">' . $displayButton . '</span>';
             } else {


### PR DESCRIPTION
## Problème

Sur la carte d'un modèle encore ouvert, le bouton « Verrouiller » affichait un cadenas **fermé** : l'icône représentait le résultat de l'action et non l'état de l'objet, ce qui se lit comme si le modèle était déjà verrouillé alors que le bouton est justement actif parce qu'il ne l'est pas.

## Changements

L'icône reflète désormais l'état courant de l'objet, sur les 6 fichiers concernés (12 occurrences) :

| Bouton | Avant | Après |
|---|---|---|
| Verrouiller — modèle, question, groupe de questions, contrôle, questionnaire, action de masse | `fa-lock` | `fa-lock-open` |
| Réouvrir — contrôle, questionnaire | `fa-lock-open` | `fa-lock` |

Les deux sont retournés ensemble : les cartes contrôle et questionnaire affichent l'un ou l'autre selon l'état, ne changer que « Verrouiller » leur aurait donné le même cadenas ouvert.

Les variantes refusées (`butActionRefused`, quand l'objet n'est pas encore validé) et les variantes mobiles (`fa-2x`) suivent la même règle.

## Tests

Rendu vérifié sur les trois états : modèle validé (bouton actif, cadenas ouvert), modèle verrouillé (bouton refusé, cadenas ouvert), contrôle verrouillé (bouton « Réouvrir », cadenas fermé).

## À noter

Digirisk utilise encore l'ancienne convention sur ses cartes accident, enquête, permis de feu et plan de prévention. Les deux modules ne sont plus alignés tant que la même correction n'y est pas portée.

## Fichiers modifiés

- `class/actions_digiquali.class.php`
- `view/control/control_card.php`
- `view/question/question_card.php`
- `view/questiongroup/questiongroup_card.php`
- `view/sheet/sheet_card.php`
- `view/survey/survey_card.php`

Close #2569

🤖 Generated with [Claude Code](https://claude.com/claude-code)
