### PR TITLE
#2566 [PDF] fix: retour à la ligne du bandeau de groupe dans la fiche de contrôle

### DIFF
--- a/core/modules/digiquali/digiqualidocuments/controldocument/pdf_controldocument.modules.php
+++ b/core/modules/digiquali/digiqualidocuments/controldocument/pdf_controldocument.modules.php
@@ -685,23 +685,35 @@ class pdf_controldocument extends SaturneDocumentModel
 
     private function drawGroupBanner($pdf, string $groupLabel, int $qCount, array $stats): void
     {
-        $pageW   = $pdf->getPageWidth();
-        $usableW = $pageW - $this->marge_gauche - $this->marge_droite;
-        $x       = $this->marge_gauche;
-        $y       = $pdf->GetY();
-        $h       = 7;
+        $pageW     = $pdf->getPageWidth();
+        $usableW   = $pageW - $this->marge_gauche - $this->marge_droite;
+        $x         = $this->marge_gauche;
+        $lineH     = 4;
+        $countText = $qCount . ' questions';
+
+        // The counter keeps a column of its own on the right, the label wraps in what is left
+        $pdf->SetFont('', '', 7.5);
+        $countW = $pdf->GetStringWidth($countText) + 4;
+        $labelW = $usableW - 6 - $countW;
+
+        // Height follows the wrapped label so a long group name never overflows the banner
+        $pdf->SetFont('', 'B', 8.5);
+        $labelH = max(1, $pdf->getNumLines($groupLabel, $labelW)) * $lineH;
+        $h      = max(7, $labelH + 3);
+
+        $this->checkPageBreak($pdf, $h + 5);
+        $y = $pdf->GetY();
 
         $this->fillRect($pdf, $x, $y, $usableW, $h, [232, 238, 245]);
 
         $pdf->SetTextColor(...$this->colorNavy);
         $pdf->SetFont('', 'B', 8.5);
-        $pdf->SetXY($x + 3, $y + 1.5);
-        $pdf->Cell(80, 4, $groupLabel, 0, 0, 'L');
+        $pdf->MultiCell($labelW, $lineH, $groupLabel, 0, 'L', 0, 0, $x + 3, $y + 1.5, true, 0, false, true, $h - 3, 'T', false);
 
         $pdf->SetTextColor(...$this->colorGray);
         $pdf->SetFont('', '', 7.5);
-        $pdf->SetXY($x + 84, $y + 1.5);
-        $pdf->Cell(30, 4, $qCount . ' questions', 0, 0, 'L');
+        $pdf->SetXY($x + 3 + $labelW, $y + 1.5);
+        $pdf->Cell($countW, $lineH, $countText, 0, 0, 'R');
 
         $pdf->SetTextColor(0, 0, 0);
         $pdf->SetDrawColor(128, 128, 128);
@@ -1494,7 +1506,6 @@ class pdf_controldocument extends SaturneDocumentModel
             }
 
             if ($group !== null) {
-                $this->checkPageBreak($pdf, 12);
                 $this->drawGroupBanner($pdf, 'Groupe : ' . $group->label, count($questions), $groupStats);
             }
 


### PR DESCRIPTION
## Problème

Dans la fiche de contrôle PDF, le bandeau « Groupe : … » écrivait le libellé du groupe dans une
cellule de largeur fixe (80 mm) sans retour à la ligne. TCPDF ne coupe pas le texte d'un `Cell` :
un libellé long (critères Qualiopi, 100 à 175 caractères) passait par-dessus le compteur
« N questions » puis débordait de la page.

## Correctif

- Le compteur « N questions » garde sa propre colonne à droite, le libellé se répartit sur la
  largeur restante via un `MultiCell`.
- La hauteur du bandeau est calculée à partir du nombre de lignes du libellé (`getNumLines`),
  au lieu des 7 mm figés.
- Le saut de page est vérifié avec la hauteur réelle du bandeau, depuis `drawGroupBanner()` :
  le `checkPageBreak()` en dur du côté appelant ne connaissait pas la hauteur et ne protégeait
  plus un bandeau sur trois lignes.

## Vérification

PDF régénéré sur le modèle « Audit Interne Qualiopi » (7 groupes, libellés de 97 à 175
caractères) : chaque bandeau tient sur 2 lignes dans la largeur utile, le compteur reste aligné
à droite sans chevauchement, et aucun bandeau n'est orphelin en bas de page.

## Fichiers modifiés

- `core/modules/digiquali/digiqualidocuments/controldocument/pdf_controldocument.modules.php`

Close #2566

