### PR TITLE
#2578 [PublicAnswer] feat: actions correctives sur l'interface publique

### DIFF
--- a/admin/publicinterface.php
+++ b/admin/publicinterface.php
@@ -138,6 +138,11 @@ $constArray['digiquali'] = [
         'name'        => 'AnswerPublicInterfaceShowTitle',
         'description' => 'AnswerPublicInterfaceShowTitleDescription',
         'code'        => 'DIGIQUALI_ANSWER_PUBLIC_INTERFACE_SHOW_TITLE',
+    ],
+    'AnswerPublicInterfaceAddAction' => [
+        'name'        => 'AnswerPublicInterfaceAddAction',
+        'description' => 'AnswerPublicInterfaceAddActionDescription',
+        'code'        => 'DIGIQUALI_ANSWER_PUBLIC_INTERFACE_ADD_ACTION',
     ]
 ];
 require __DIR__ . '/../../saturne/core/tpl/admin/object/object_const_view.tpl.php';

--- a/class/control.class.php
+++ b/class/control.class.php
@@ -1317,8 +1317,11 @@ class Control extends SaturneObject
      */
     public function displayAnswers(ControlLine $objectLine, array $questionsAndGroups, bool $isFrontend, int $level = 0)
     {
-        // $user is required by the included template, which reads the per-user display preferences
+        // $user is required by the included template, which reads the per-user display preferences.
+        // The task permissions and the public flag are page level variables the template needs too :
+        // without them a question rendered through here would silently lose its corrective actions
         global $conf, $langs, $user;
+        global $permissionToAddTask, $permissionToReadTask, $permissionToDeleteTask, $permissionToManageTaskTimeSpent, $taskPublicView;
 
         $object = $this;
 

--- a/class/survey.class.php
+++ b/class/survey.class.php
@@ -746,8 +746,11 @@ class Survey extends SaturneObject
      */
     public function displayAnswers(SurveyLine $objectLine, array $questionsAndGroups, bool $isFrontend = false, int $level = 0)
     {
-        // $user is required by the included template, which reads the per-user display preferences
+        // $user is required by the included template, which reads the per-user display preferences.
+        // The task permissions and the public flag are page level variables the template needs too :
+        // without them a question rendered through here would silently lose its corrective actions
         global $conf, $langs, $user;
+        global $permissionToAddTask, $permissionToReadTask, $permissionToDeleteTask, $permissionToManageTaskTimeSpent, $taskPublicView;
 
         $object = $this;
 

--- a/core/tpl/answers/answers_task_view.tpl.php
+++ b/core/tpl/answers/answers_task_view.tpl.php
@@ -26,38 +26,51 @@
  * Global    : $langs, $object
  * Objects   : $objectLine
  * Variables : $permissionToAddTask, $permissionToDeleteTask, $permissionToManageTaskTimeSpent
+ * Optional  : $taskPublicView, set by the public interface when the visitor is not a logged in user
+ *             allowed to read projects. What it hides is only ever shown to someone who is.
  */ ?>
 
 <div class="question__list-actions" id="question_task_list<?php echo $objectLine->id ?>" data-objectline-id="<?php echo $objectLine->id ?>" data-objectline-element="<?php echo $objectLine->element ?>">
-    <?php foreach ($objectLine->linkedObjects['project_task'] ?? [] as $task) :
+    <?php
+    // Who is on the action, what it costs and the links into the back office are only shown to a visitor
+    // who is logged in and allowed to read projects. Anyone else gets the action itself, in plain text
+    $taskViewPublic = !empty($taskPublicView);
+
+    foreach ($objectLine->linkedObjects['project_task'] ?? [] as $task) :
         $taskInfos = get_task_infos($task); ?>
         <div class="question__action" id="answer_task<?php echo $task->id ?>" data-task-id="<?php echo $task->id; ?>">
             <div class="question__action-check">
                 <label>
-                    <input type="checkbox" <?php echo ($taskInfos['task']['progress'] == 100 ? 'checked' : ''); ?>/>
+                    <input type="checkbox" <?php echo ($taskInfos['task']['progress'] == 100 ? 'checked' : ''); ?> <?php echo (empty($permissionToAddTask) ? 'disabled' : ''); ?>/>
                 </label>
             </div>
             <div class="question__action-body">
                 <div class="question__action-metas">
-                    <span class="question__action-metas-ref"><?php echo $taskInfos['task']['ref']; ?></span>
-                    <span class="question__action-metas-author"><?php echo $taskInfos['task']['author']; ?></span>
-                    <?php if (!empty($taskInfos['task']['assigned'])) : ?>
-                        <span class="question__action-metas-assigned"><i class="fas fa-user-check pictofixedwidth"></i><?php echo implode(', ', $taskInfos['task']['assigned']); ?></span>
+                    <span class="question__action-metas-ref"><?php echo $taskViewPublic ? dol_escape_htmltag($task->ref) : $taskInfos['task']['ref']; ?></span>
+                    <?php if (!$taskViewPublic) : ?>
+                        <span class="question__action-metas-author"><?php echo $taskInfos['task']['author']; ?></span>
+                        <?php if (!empty($taskInfos['task']['assigned'])) : ?>
+                            <span class="question__action-metas-assigned"><i class="fas fa-user-check pictofixedwidth"></i><?php echo implode(', ', $taskInfos['task']['assigned']); ?></span>
+                        <?php endif; ?>
                     <?php endif; ?>
                     <span class="question__action-metas-date"><i class="fas fa-calendar-alt pictofixedwidth"></i><?php echo $taskInfos['task']['date']; ?></span>
-                    <div class="modal-open">
-                        <?php if (!empty($permissionToManageTaskTimeSpent)) : ?>
-                            <input type="hidden" class="modal-options" data-modal-to-open="answer_task_timespent_list" data-from-id="<?php echo $task->id; ?>" data-from-module="<?php echo $object->module; ?>">
-                        <?php endif; ?>
-                        <span class="question__action-metas-time"><i class="fas fa-clock pictofixedwidth"></i><?php echo $taskInfos['task']['time']; ?></span>
-                    </div>
+                    <?php if (!$taskViewPublic) : ?>
+                        <div class="modal-open">
+                            <?php if (!empty($permissionToManageTaskTimeSpent)) : ?>
+                                <input type="hidden" class="modal-options" data-modal-to-open="answer_task_timespent_list" data-from-id="<?php echo $task->id; ?>" data-from-module="<?php echo $object->module; ?>">
+                            <?php endif; ?>
+                            <span class="question__action-metas-time"><i class="fas fa-clock pictofixedwidth"></i><?php echo $taskInfos['task']['time']; ?></span>
+                        </div>
+                    <?php endif; ?>
                     <?php if (!empty($permissionToManageTaskTimeSpent)) : ?>
                         <div class="modal-open">
                             <input type="hidden" class="modal-options" data-modal-to-open="answer_task_timespent_add" data-from-id="<?php echo $task->id; ?>" data-from-module="<?php echo $object->module; ?>">
                             <i class="fas fa-plus"></i>
                         </div>
                     <?php endif; ?>
-                    <span class="question__action-metas-budget"><i class="fas fa-coins pictofixedwidth"></i><?php echo $taskInfos['task']['budget']; ?></span>
+                    <?php if (!$taskViewPublic) : // Like the public action plan, an anonymous visitor is not told what the action costs ?>
+                        <span class="question__action-metas-budget"><i class="fas fa-coins pictofixedwidth"></i><?php echo $taskInfos['task']['budget']; ?></span>
+                    <?php endif; ?>
                     <span class="question__action-metas-progress">
                         <i class="fas fa-tasks pictofixedwidth"></i>
                         <?php if (!empty($permissionToAddTask)) : ?>

--- a/core/tpl/digiquali_answers_task_action.tpl.php
+++ b/core/tpl/digiquali_answers_task_action.tpl.php
@@ -27,15 +27,17 @@
  * Parameters : $action
  * Objects    : $task
  * Variables  : $permissionToAddTask, $permissionToDeleteTask, $permissionToManageTaskTimeSpent, $taskNextValue
+ * Optional   : $taskForcedProjectId, the only project the caller accepts to create into
  */
 
 // Task action
 if ($action == 'add_task' && !empty($permissionToAddTask)) {
     $data = json_decode(file_get_contents('php://input'), true);
 
-    $task->ref        = $taskNextValue;
-    $task->label      = $data['label'];
-    $task->fk_project = $data['fk_project'];
+    $task->ref   = $taskNextValue;
+    $task->label = $data['label'];
+    // The project comes from the page on the public interface, where the posted one cannot be trusted
+    $task->fk_project = !empty($taskForcedProjectId) ? $taskForcedProjectId : $data['fk_project'];
     $task->date_c     = dol_now();
     if (!empty($data['date_start'])) {
         $task->date_start = dol_stringtotime($data['date_start']);
@@ -74,7 +76,10 @@ if ($action == 'update_task' && !empty($permissionToAddTask)) {
     if (!empty($data['date_end'])) {
         $task->date_end = dol_stringtotime($data['date_end']);
     }
-    $task->budget_amount = $data['budget'];
+    // The frontend form has no budget field : an absent key must leave the budget alone, not wipe it
+    if (array_key_exists('budget', $data)) {
+        $task->budget_amount = $data['budget'];
+    }
     if (isset($data['progress'])) {
         $task->progress = max(0, min(100, (int) $data['progress']));
     }

--- a/core/tpl/digiquali_question_single.tpl.php
+++ b/core/tpl/digiquali_question_single.tpl.php
@@ -78,7 +78,8 @@ if (!isset($user->conf->DIGIQUALI_SHOW_ONLY_QUESTIONS_WITH_NO_ANSWER) || empty($
                                     <i class="fas fa-list"></i><i class="fas fa-plus-circle button-add"></i>
                                 </div>
                             <?php endif; ?>
-                            <?php if (empty($object->project) && !empty($permissionToAddTask)) :
+                            <?php // The frontend has nowhere to go and attach a project : an inert button would only puzzle the user
+                            if (empty($object->project) && !empty($permissionToAddTask) && empty($isFrontend)) :
                                 print '<div class="wpeo-button button-square-50 wpeo-tooltip-event" aria-label="' . $langs->transnoentities('AddProject') . '" id="task-disable" style="background-color: #ececec; border-color: #ececec; color: rgba(0, 0, 0, 0.4) !important;">';
                                 print '    <input type="hidden" class="modal-options" data-modal-to-open="answer_task_add" data-from-id="' . $objectLine->id . '" data-from-type="' . $objectLine->element . '"/>';
                                 print '    <i class="fas fa-list"></i><i class="fas fa-plus-circle button-add"></i>';

--- a/core/tpl/modal/modal_task_add.tpl.php
+++ b/core/tpl/modal/modal_task_add.tpl.php
@@ -26,13 +26,20 @@
  * Global   : $langs
  * Objects  : $object, $form
  * Variable : $taskNextValue
- */ ?>
+ * Optional : $taskPublicView, set by the public interface for a visitor who is not a logged in user allowed to read projects
+ */
+
+// The public interface is opened with a track_id and nothing else : it must neither list the internal
+// users nor speak of money. What it leaves out stays a back-office matter, on the action plan tab.
+$taskModalShowInternals = empty($taskPublicView); ?>
 
 <div class="wpeo-modal modal-answer-task-add" id="answer_task_add" data-project-id="<?php echo $object->project->id; ?>">
     <div class="modal-container wpeo-modal-event">
         <!-- Modal-Header -->
         <div class="modal-header">
-            <h2 class="modal-title"><?php echo $langs->trans('TaskCreate') . ' ' . $taskNextValue . ' ' . $langs->trans('AT') . '  ' . $langs->trans('Project') . '  ' . $object->project->getNomUrl(); ?></h2>
+            <h2 class="modal-title"><?php echo $taskModalShowInternals
+                ? $langs->trans('TaskCreate') . ' ' . $taskNextValue . ' ' . $langs->trans('AT') . '  ' . $langs->trans('Project') . '  ' . $object->project->getNomUrl()
+                : $langs->trans('ActionPlanNewAction'); ?></h2>
             <div class="modal-close"><i class="fas fa-2x fa-times"></i></div>
         </div>
         <!-- Modal-Content -->
@@ -43,11 +50,13 @@
                         <span class="title"><?php echo $langs->trans('Label'); ?></span>
                         <input type="text" id="answer-task-label" name="label">
                     </label>
-                    <label>
-                        <span class="title"><?php echo $langs->trans('AffectedTo'); ?></span>
-                        <?php echo $form->select_dolusers('', 'answer-task-assigned-user', 1); ?>
-                    </label>
-                    <div class="answer-task-date wpeo-gridlayout grid-3">
+                    <?php if ($taskModalShowInternals) : ?>
+                        <label>
+                            <span class="title"><?php echo $langs->trans('AffectedTo'); ?></span>
+                            <?php echo $form->select_dolusers('', 'answer-task-assigned-user', 1); ?>
+                        </label>
+                    <?php endif; ?>
+                    <div class="answer-task-date wpeo-gridlayout <?php echo $taskModalShowInternals ? 'grid-3' : 'grid-2'; ?>">
                         <div>
                             <label>
                                 <span class="title"><?php echo $langs->trans('DateStart'); ?></span>
@@ -60,12 +69,14 @@
                                 <input type="datetime-local" id="answer-task-end-date" name="date_end">
                             </label>
                         </div>
-                        <div>
-                            <label>
-                                <span class="title"><?php echo $langs->trans('Budget'); ?></span>
-                                <input type="number" id="answer-task-budget" name="budget" min="0">
-                            </label>
-                        </div>
+                        <?php if ($taskModalShowInternals) : ?>
+                            <div>
+                                <label>
+                                    <span class="title"><?php echo $langs->trans('Budget'); ?></span>
+                                    <input type="number" id="answer-task-budget" name="budget" min="0">
+                                </label>
+                            </div>
+                        <?php endif; ?>
                     </div>
                 </div>
             </div>

--- a/core/tpl/modal/modal_task_edit.tpl.php
+++ b/core/tpl/modal/modal_task_edit.tpl.php
@@ -25,7 +25,11 @@
  * The following vars must be defined:
  * Global   : $langs
  * Objects  : $object, $task, $form
+ * Optional : $taskPublicView, set by the public interface for a visitor who is not a logged in user allowed to read projects
  */
+
+// Same rule as the add modal : the public interface neither lists the internal users nor speaks of money
+$taskModalShowInternals = empty($taskPublicView);
 
 $taskInfos = get_task_infos($task); ?>
 
@@ -33,17 +37,23 @@ $taskInfos = get_task_infos($task); ?>
     <div class="modal-container wpeo-modal-event">
         <!-- Modal-Header -->
         <div class="modal-header">
-            <h2 class="modal-title"><?php echo $langs->trans('TaskEdit') . ' ' . $task->getNomUrl() . ' ' . $langs->trans('AT') . '  ' . $langs->trans('Project') . '  ' . $object->project->getNomUrl(); ?></h2>
+            <h2 class="modal-title"><?php echo $taskModalShowInternals
+                ? $langs->trans('TaskEdit') . ' ' . $task->getNomUrl() . ' ' . $langs->trans('AT') . '  ' . $langs->trans('Project') . '  ' . $object->project->getNomUrl()
+                : $langs->trans('Modify') . ' ' . dol_escape_htmltag($task->ref); ?></h2>
             <div class="modal-close"><i class="fas fa-2x fa-times"></i></div>
         </div>
         <!-- Modal-Content -->
         <div class="modal-content answer-task-content">
             <div>
-                <span class="answer-task-reference"><?php echo $taskInfos['task']['ref']; ?></span>
-                <span class="answer-task-author"><?php echo $taskInfos['task']['author']; ?></span>
+                <span class="answer-task-reference"><?php echo $taskModalShowInternals ? $taskInfos['task']['ref'] : dol_escape_htmltag($task->ref); ?></span>
+                <?php if ($taskModalShowInternals) : ?>
+                    <span class="answer-task-author"><?php echo $taskInfos['task']['author']; ?></span>
+                <?php endif; ?>
                 <span class="answer-task-date"><i class="fas fa-calendar-alt pictofixedwidth"></i><?php echo $taskInfos['task']['date']; ?></span>
-                <span class="answer-total-task-timespent"><i class="fas fa-clock pictofixedwidth"></i><?php echo $taskInfos['task']['time']; ?></span>
-                <span><i class="fas fa-coins pictofixedwidth"></i><?php echo $taskInfos['task']['budget']; ?></span>
+                <?php if ($taskModalShowInternals) : ?>
+                    <span class="answer-total-task-timespent"><i class="fas fa-clock pictofixedwidth"></i><?php echo $taskInfos['task']['time']; ?></span>
+                    <span><i class="fas fa-coins pictofixedwidth"></i><?php echo $taskInfos['task']['budget']; ?></span>
+                <?php endif; ?>
             </div>
             <div class="answer-task-content">
                 <div class="answer-task-title">
@@ -52,13 +62,15 @@ $taskInfos = get_task_infos($task); ?>
                         <input type="text" id="answer-task-label" name="label" value="<?php echo $task->label; ?>">
                     </label>
                 </div>
-                <div class="answer-task-affected">
-                    <label>
-                        <span class="title"><?php echo $langs->trans('AffectedTo'); ?></span>
-                        <?php echo $form->select_dolusers($taskInfos['task']['assigned_user_id'], 'answer-task-edit-assigned-user', 1); ?>
-                    </label>
-                </div>
-                <div class="answer-task-date wpeo-gridlayout grid-3">
+                <?php if ($taskModalShowInternals) : ?>
+                    <div class="answer-task-affected">
+                        <label>
+                            <span class="title"><?php echo $langs->trans('AffectedTo'); ?></span>
+                            <?php echo $form->select_dolusers($taskInfos['task']['assigned_user_id'], 'answer-task-edit-assigned-user', 1); ?>
+                        </label>
+                    </div>
+                <?php endif; ?>
+                <div class="answer-task-date wpeo-gridlayout <?php echo $taskModalShowInternals ? 'grid-3' : 'grid-2'; ?>">
                     <div>
                         <label>
                             <span class="title"><?php echo $langs->trans('DateStart'); ?></span>
@@ -71,12 +83,14 @@ $taskInfos = get_task_infos($task); ?>
                             <?php print '<input type="datetime-local" id="answer-task-end-date" name="date_end" value="' . (!empty($task->date_end) ? dol_print_date($task->date_end, '%Y-%m-%dT%H:%M') : '') . '">'; ?>
                         </label>
                     </div>
-                    <div>
-                        <label>
-                            <span class="title"><?php echo $langs->trans('Budget'); ?></span>
-                            <input type="number" id="answer-task-budget" name="budget" min="0" value="<?php echo $task->budget_amount; ?>">
-                        </label>
-                    </div>
+                    <?php if ($taskModalShowInternals) : ?>
+                        <div>
+                            <label>
+                                <span class="title"><?php echo $langs->trans('Budget'); ?></span>
+                                <input type="number" id="answer-task-budget" name="budget" min="0" value="<?php echo $task->budget_amount; ?>">
+                            </label>
+                        </div>
+                    <?php endif; ?>
                 </div>
                 <div class="answer-task-progress-field">
                     <label>

--- a/langs/en_US/digiquali.lang
+++ b/langs/en_US/digiquali.lang
@@ -130,3 +130,10 @@ AnswerWizardValidateText  = You answered %s question(s) out of %s. Once validate
 #
 
 CommentLibrary = Comment library
+
+#
+# Public interface
+#
+
+AnswerPublicInterfaceAddAction            = Enable corrective actions on the public answer interface
+AnswerPublicInterfaceAddActionDescription = Lets a visitor read the corrective actions of a question and add one from the public interface. The control has to be attached to a project, which the actions are created into. The assignee, the budget and the time spent stay a back-office matter.

--- a/langs/fr_FR/digiquali.lang
+++ b/langs/fr_FR/digiquali.lang
@@ -86,6 +86,8 @@ AnswerPublicInterfaceUseSignatory            = Activer la signature sur l'interf
 AnswerPublicInterfaceUseSignatoryDescription = Rend obligatoire l'utilisation de la signature sur l'interface publique de réponse aux questions
 AnswerPublicInterfaceShowTitle               = Activer le titre sur l'interface publique de réponse aux questions
 AnswerPublicInterfaceShowTitleDescription    = Permet d'afficher le titre du contrôle sur l'interface publique de réponse aux questions
+AnswerPublicInterfaceAddAction               = Activer les actions correctives sur l'interface publique de réponse aux questions
+AnswerPublicInterfaceAddActionDescription    = Permet de consulter les actions correctives d'une question et d'en ajouter depuis l'interface publique. Le contrôle doit être rattaché à un projet, dans lequel les actions sont créées. Le responsable, le budget et le temps passé restent réservés au back-office.
 
 #
 # Questions

--- a/lib/digiquali_control.lib.php
+++ b/lib/digiquali_control.lib.php
@@ -787,6 +787,44 @@ function digiquali_count_control_actions(int $controlId): int
 }
 
 /**
+ * Ids of the tasks that make up the action plan of a control.
+ *
+ * The public answer interface has no logged in user to check rights against : what it is allowed to
+ * touch is what the control behind the track_id carries. This lists it in one query, without building
+ * every action the way digiquali_get_control_actions() does.
+ *
+ * @param  int   $controlId Id of the control
+ * @return int[]            Ids of the tasks carried by the answers of the control
+ */
+function digiquali_get_control_action_task_ids(int $controlId): array
+{
+    global $db;
+
+    if ($controlId <= 0) {
+        return [];
+    }
+
+    $lines  = '(SELECT rowid FROM ' . $db->prefix() . 'digiquali_controldet WHERE fk_control = ' . $controlId . ' AND status > 0)';
+    $sql    = "SELECT fk_source AS task_id FROM " . $db->prefix() . "element_element WHERE sourcetype = 'project_task' AND targettype = 'controldet' AND fk_target IN " . $lines;
+    $sql   .= ' UNION ';
+    $sql   .= "SELECT fk_target AS task_id FROM " . $db->prefix() . "element_element WHERE sourcetype = 'controldet' AND targettype = 'project_task' AND fk_source IN " . $lines;
+
+    $resql = $db->query($sql);
+    if (!$resql) {
+        dol_syslog('digiquali_get_control_action_task_ids ' . $db->lasterror(), LOG_ERR);
+        return [];
+    }
+
+    $taskIds = [];
+    while ($obj = $db->fetch_object($resql)) {
+        $taskIds[] = (int) $obj->task_id;
+    }
+    $db->free($resql);
+
+    return $taskIds;
+}
+
+/**
  * Keep the actions of a control action plan matching the filters of the page.
  *
  * An action is spread over a task, the control line it answers and the answer given to that line, so

--- a/public/public_answer.php
+++ b/public/public_answer.php
@@ -76,7 +76,7 @@ require_once __DIR__ . '/../lib/digiquali_control.lib.php';
 global $conf, $db, $hookmanager, $moduleNameLowerCase, $langs, $user;
 
 // Load translation files required by the page
-saturne_load_langs();
+saturne_load_langs(['projects']);
 
 // Get parameters
 $trackID   = GETPOST('track_id', 'alpha');
@@ -129,6 +129,52 @@ if (getDolGlobalInt('DIGIQUALI_ANSWER_PUBLIC_INTERFACE_USE_SIGNATORY')) {
     $signatory->fetch(0, '', ' AND status >= ' . SaturneSignature::STATUS_REGISTERED . ' AND object_type= ' . "'" . $object->element . "'" . ' AND fk_object = ' . "'" . $object->id . "'");
 }
 
+// Corrective actions carried by the answers. An action is a project task linked to the answer of a
+// question, exactly as on the control card. The public interface only opens that door when the option
+// says so, and only for a control attached to the project the actions are created into
+$publicInterfaceActions = getDolGlobalInt('DIGIQUALI_ANSWER_PUBLIC_INTERFACE_ADD_ACTION') && $object->id > 0 && $object->element == 'control' && isModEnabled('projet');
+
+$task                            = null;
+$taskNextValue                   = '';
+$taskForcedProjectId             = 0;
+$permissionToReadTask            = 0;
+$permissionToAddTask             = 0;
+$permissionToDeleteTask          = 0;
+$permissionToManageTaskTimeSpent = 0;
+
+// Whoever opens the public link is anonymous until proven otherwise : sensitive content (who is on an
+// action, what it costs, how long it took, the links into the back office) is only ever shown to a
+// visitor who is logged in and allowed to read projects
+$visitorUser = new User($db);
+if (!empty($_SESSION['dol_login'])) {
+    $visitorUser->fetch('', $_SESSION['dol_login'], '', 1);
+    $visitorUser->getrights();
+}
+$taskPublicView = !($visitorUser->id > 0 && ($visitorUser->hasRight('project', 'lire') || $visitorUser->hasRight('project', 'all', 'lire')));
+
+if ($publicInterfaceActions) {
+    // Load Dolibarr libraries
+    require_once DOL_DOCUMENT_ROOT . '/projet/class/project.class.php';
+
+    // Load Saturne libraries
+    require_once __DIR__ . '/../../saturne/class/task/saturnetask.class.php';
+
+    if (!empty($object->projectid)) {
+        $object->fk_project = $object->projectid; // Need special case because projectid is only on control object
+        $object->fetch_project();
+    }
+    $taskForcedProjectId = (int) ($object->project->id ?? 0);
+
+    $task = new SaturneTask($db);
+    list($refTaskMod) = saturne_require_objects_mod(['project/task' => getDolGlobalString('PROJECT_TASK_ADDON')]);
+    $taskNextValue    = $refTaskMod->getNextValue($object->id, $object->element);
+
+    // There is no logged in user to check rights against : the option is what opens reading the actions
+    // of this control and adding one to it, and answers are only completed while the control is a draft
+    $permissionToReadTask = 1;
+    $permissionToAddTask  = ($object->status == $object::STATUS_DRAFT && $taskForcedProjectId > 0) ? 1 : 0;
+}
+
 /*
  * Actions
  */
@@ -153,6 +199,29 @@ if (empty($resHook)) {
     if (in_array($action, ['uploadPhoto', 'uploadFile', 'deletePhoto', 'deleteFile'])) {
         if ($object->id > 0 && $object->status == $object::STATUS_DRAFT && digiquali_answer_media_dir_is_allowed($object, $action)) {
             require_once __DIR__ . '/../core/tpl/actions/digiquali_media_block_actions.tpl.php';
+        }
+    }
+
+    // Actions add_task, fetch_task, update_task, update_task_progress, check_task posted by the corrective
+    // actions of a question. Deleting an action and logging time on it stay back-office matters
+    if ($publicInterfaceActions && in_array($action, ['add_task', 'fetch_task', 'update_task', 'update_task_progress', 'check_task'])) {
+        // An anonymous request must not reach past the control behind the track_id : the answer an action
+        // is attached to, and the action an update targets, both have to belong to this control
+        $taskRequestData = json_decode(file_get_contents('php://input'), true) ?: [];
+
+        if ($action == 'add_task') {
+            $answerLineClass   = get_class($objectLine);
+            $answerLine        = new $answerLineClass($db);
+            $taskActionAllowed = ($answerLine->fetch((int) ($taskRequestData['objectLine_id'] ?? 0)) > 0 && $answerLine->fk_control == $object->id);
+        } else {
+            // Opening the add modal also asks for a task, with the id of an answer line : it finds nothing
+            // here, which is right, the modal it renders does not need one
+            $requestedTaskId   = ($action == 'check_task' ? GETPOSTINT('task_id') : (int) ($taskRequestData['task_id'] ?? $taskRequestData['from_id'] ?? 0));
+            $taskActionAllowed = in_array($requestedTaskId, digiquali_get_control_action_task_ids($object->id), true);
+        }
+
+        if ($taskActionAllowed) {
+            require_once __DIR__ . '/../core/tpl/digiquali_answers_task_action.tpl.php';
         }
     }
 
@@ -193,6 +262,13 @@ print '<div class="question-answer-container question-answer-container-pwa publi
 $publicInterface = true;
 
 $isFrontend = true;
+
+// Modals of the corrective actions, inside the container the JS looks them up from
+if (!empty($permissionToAddTask)) {
+    $form = new Form($db);
+    require_once __DIR__ . '/../core/tpl/modal/modal_task_add.tpl.php';
+    require_once __DIR__ . '/../core/tpl/modal/modal_task_edit.tpl.php';
+}
 
 // Intro screen of the wizard: what is being controlled
 $wizardIntroHtml = '';


### PR DESCRIPTION
## Contexte

Sur l'interface publique de réponse, une question ne proposait aucune action corrective : le bouton
d'ajout et la liste des actions n'existaient que sur la fiche contrôle. Les actions correctives sont
maintenant disponibles côté public, derrière une option de réglage.

## Changements

- **Nouvelle option** `Activer les actions correctives sur l'interface publique de réponse aux questions`
  (`DIGIQUALI_ANSWER_PUBLIC_INTERFACE_ADD_ACTION`), dans Configuration > Interface publique. Désactivée
  par défaut : sans elle, la page publique est strictement identique à avant.
- **Interface publique** : bouton d'ajout d'action sur chaque question, liste des actions de la question
  sous celle-ci, modification et avancement d'une action. Uniquement pour un contrôle **brouillon**
  **rattaché à un projet** (c'est dans ce projet que les tâches sont créées), jamais pour un questionnaire.
- **Contenu sensible réservé aux personnes connectées et habilitées** : le responsable, le budget, le
  temps passé, l'auteur et les liens vers le back-office ne s'affichent que si le visiteur a une session
  Dolibarr ouverte avec le droit de lecture des projets. Un visiteur anonyme voit la référence, le
  libellé, les dates et l'avancement, en texte simple — même parti pris que l'interface publique du plan
  d'action. La suppression et les temps passés restent des actions de back-office.
- **Portée des requêtes vérifiée côté serveur** : une requête anonyme ne peut créer une action que sur
  une réponse du contrôle ouvert par le `track_id`, ni modifier une tâche qui n'appartient pas à son plan
  d'action ; le projet posté est ignoré au profit de celui du contrôle.
- `Control::displayAnswers()` et `Survey::displayAnswers()` importent désormais les permissions de tâche :
  sans cela une question rendue via cette méthode (assistant mobile, sous-groupes de la fiche contrôle)
  perdait silencieusement ses actions correctives.
- Correction au passage : la mise à jour d'une action ne remet plus le budget à zéro quand le formulaire
  ne porte pas ce champ, et la case « terminée » est désactivée sans droit de modification.

## Tests

- Page publique d'un contrôle brouillon avec projet : création d'une action depuis la modale (rendu
  headless, clic réel), affichage dans la liste, modification, avancement — tâche créée dans le bon projet
  et liée à la bonne réponse.
- Option désactivée : aucun bouton, aucune modale, et une requête `add_task` forgée ne crée rien.
- Requêtes forgées : ligne de réponse d'un autre contrôle, tâche hors plan d'action, suppression,
  projet différent de celui du contrôle — toutes refusées, aucune donnée modifiée.
- Non-régression : fiche contrôle (avec et sans projet, avec groupes de questions) et page publique d'un
  questionnaire rendues sans warning ni changement d'affichage.

## Fichiers modifiés

- `admin/publicinterface.php`
- `class/control.class.php`, `class/survey.class.php`
- `core/tpl/answers/answers_task_view.tpl.php`
- `core/tpl/digiquali_answers_task_action.tpl.php`
- `core/tpl/digiquali_question_single.tpl.php`
- `core/tpl/modal/modal_task_add.tpl.php`, `core/tpl/modal/modal_task_edit.tpl.php`
- `langs/fr_FR/digiquali.lang`, `langs/en_US/digiquali.lang`
- `lib/digiquali_control.lib.php`
- `public/public_answer.php`

Close #2578
